### PR TITLE
試合管理画面 UITableView 実装

### DIFF
--- a/SoccerNoteApp.xcodeproj/project.pbxproj
+++ b/SoccerNoteApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */; };
+		5D14B37625565ADB002CA3D4 /* GameManagementTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */; };
 		5DAC50D3253DF01400F788BA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D2253DF01400F788BA /* AppDelegate.swift */; };
 		5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D4253DF01400F788BA /* SceneDelegate.swift */; };
 		5DAC50D7253DF01400F788BA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D6253DF01400F788BA /* ViewController.swift */; };
@@ -37,6 +38,7 @@
 
 /* Begin PBXFileReference section */
 		5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementViewController.swift; sourceTree = "<group>"; };
+		5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementTableViewCell.swift; sourceTree = "<group>"; };
 		5DAC50CF253DF01400F788BA /* SoccerNoteApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SoccerNoteApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DAC50D2253DF01400F788BA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5DAC50D4253DF01400F788BA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 				5DAC50D2253DF01400F788BA /* AppDelegate.swift */,
 				5DAC50D4253DF01400F788BA /* SceneDelegate.swift */,
 				5DAC50D6253DF01400F788BA /* ViewController.swift */,
+				5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */,
 				5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */,
 				5DAC50D8253DF01400F788BA /* Main.storyboard */,
 				5DAC50DB253DF01600F788BA /* Assets.xcassets */,
@@ -263,6 +266,7 @@
 			files = (
 				5DAC50D7253DF01400F788BA /* ViewController.swift in Sources */,
 				5DAC50D3253DF01400F788BA /* AppDelegate.swift in Sources */,
+				5D14B37625565ADB002CA3D4 /* GameManagementTableViewCell.swift in Sources */,
 				5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */,
 				5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */,
 			);

--- a/SoccerNoteApp.xcodeproj/project.pbxproj
+++ b/SoccerNoteApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */; };
 		5DAC50D3253DF01400F788BA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D2253DF01400F788BA /* AppDelegate.swift */; };
 		5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D4253DF01400F788BA /* SceneDelegate.swift */; };
 		5DAC50D7253DF01400F788BA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D6253DF01400F788BA /* ViewController.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementViewController.swift; sourceTree = "<group>"; };
 		5DAC50CF253DF01400F788BA /* SoccerNoteApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SoccerNoteApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DAC50D2253DF01400F788BA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5DAC50D4253DF01400F788BA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 				5DAC50D2253DF01400F788BA /* AppDelegate.swift */,
 				5DAC50D4253DF01400F788BA /* SceneDelegate.swift */,
 				5DAC50D6253DF01400F788BA /* ViewController.swift */,
+				5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */,
 				5DAC50D8253DF01400F788BA /* Main.storyboard */,
 				5DAC50DB253DF01600F788BA /* Assets.xcassets */,
 				5DAC50DD253DF01600F788BA /* LaunchScreen.storyboard */,
@@ -261,6 +264,7 @@
 				5DAC50D7253DF01400F788BA /* ViewController.swift in Sources */,
 				5DAC50D3253DF01400F788BA /* AppDelegate.swift in Sources */,
 				5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */,
+				5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -15,8 +16,20 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dte-cP-JJe">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </tableView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Dte-cP-JJe" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="Aru-II-j8m"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Dte-cP-JJe" secondAttribute="trailing" id="aIh-6e-jh1"/>
+                            <constraint firstItem="Dte-cP-JJe" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="q8W-VW-Mco"/>
+                            <constraint firstItem="Dte-cP-JJe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="ri9-wb-wRv"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Game Management View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="GameManagementViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -31,6 +31,9 @@
                             <constraint firstItem="Dte-cP-JJe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="ri9-wb-wRv"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="gameManagementTableView" destination="Dte-cP-JJe" id="KlS-Te-5ii"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/SoccerNoteApp/GameManagementTableViewCell.swift
+++ b/SoccerNoteApp/GameManagementTableViewCell.swift
@@ -5,4 +5,17 @@
 //  Created by hideto c. on 2020/11/07.
 //
 
-import Foundation
+import UIKit
+
+class GameManagementTableViewCell: UITableViewCell {
+    
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+    
+}

--- a/SoccerNoteApp/GameManagementTableViewCell.swift
+++ b/SoccerNoteApp/GameManagementTableViewCell.swift
@@ -1,0 +1,8 @@
+//
+//  GameManagementTableViewCell.swift
+//  SoccerNoteApp
+//
+//  Created by hideto c. on 2020/11/07.
+//
+
+import Foundation

--- a/SoccerNoteApp/GameManagementTableViewCell.swift
+++ b/SoccerNoteApp/GameManagementTableViewCell.swift
@@ -9,7 +9,6 @@ import UIKit
 
 class GameManagementTableViewCell: UITableViewCell {
     
-    
     override func awakeFromNib() {
         super.awakeFromNib()
     }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -1,0 +1,29 @@
+//
+//  GameManagementViewController.swift
+//  SoccerNoteApp
+//
+//  Created by hideto c. on 2020/11/07.
+//
+
+import UIKit
+
+class GameManagementViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -20,7 +20,6 @@ class GameManagementViewController: UIViewController {
         gameManagementTableView.dataSource = self
         gameManagementTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
     }
-    
 }
 
 extension GameManagementViewController: UITableViewDelegate,UITableViewDataSource {
@@ -34,13 +33,7 @@ extension GameManagementViewController: UITableViewDelegate,UITableViewDataSourc
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        
         let cell = gameManagementTableView.dequeueReusableCell(withIdentifier: cellId, for: indexPath)
         return cell
-        
     }
-    
-    
-    
-    
 }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -21,6 +21,7 @@ class GameManagementViewController: UIViewController {
         gameManagementTableView.dataSource = self
         gameManagementTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
     }
+    
 }
 
 extension GameManagementViewController: UITableViewDelegate,UITableViewDataSource {
@@ -39,4 +40,5 @@ extension GameManagementViewController: UITableViewDelegate,UITableViewDataSourc
         let cell = gameManagementTableView.dequeueReusableCell(withIdentifier: cellId, for: indexPath)
         return cell
     }
+    
 }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -8,22 +8,39 @@
 import UIKit
 
 class GameManagementViewController: UIViewController {
-
+    
+    private let cellId = "cellId"
+    
+    @IBOutlet weak var gameManagementTableView: UITableView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        gameManagementTableView.delegate = self
+        gameManagementTableView.dataSource = self
+        gameManagementTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
     }
     
+}
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+extension GameManagementViewController: UITableViewDelegate,UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 80
     }
-    */
-
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 100
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let cell = gameManagementTableView.dequeueReusableCell(withIdentifier: cellId, for: indexPath)
+        return cell
+        
+    }
+    
+    
+    
+    
 }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -19,6 +19,8 @@ class GameManagementViewController: UIViewController {
         
         gameManagementTableView.delegate = self
         gameManagementTableView.dataSource = self
+        
+        //仮の実装（この後TableViewCellとの紐付けの際削除する予定）
         gameManagementTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
     }
     

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class GameManagementViewController: UIViewController {
     
+    //仮の実装
     private let cellId = "cellId"
     
     @IBOutlet weak var gameManagementTableView: UITableView!
@@ -24,10 +25,12 @@ class GameManagementViewController: UIViewController {
 
 extension GameManagementViewController: UITableViewDelegate,UITableViewDataSource {
     
+    //今後変更の可能性あり
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 80
     }
     
+    //今後変更の可能性あり
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 100
     }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class GameManagementViewController: UIViewController {
     
-    //仮の実装
+    //この後TableViewCellのXibファイルとの紐付けに使います
     private let cellId = "cellId"
     
     @IBOutlet weak var gameManagementTableView: UITableView!


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-gamemanagement-TableView https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合管理画面 試合管理TableView実装

**概要**
試合管理画面のTableViewを実装しました

**レビューで見て欲しいポイント**
コードの書き方に問題はないか。

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK 

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741

**補足**
このブランチではTableViewのみの実装でしたが、TableViewCellのファイルも作成しコードを書いてしまったので次のブランチでCell用のXibを作成し、XibとTableViewCellファイルの紐付け、最終TableViewのViewControllerとの紐付けをして行きたいと思います。