### PR TITLE
試合管理画面　UI-TableVIewCell実装

### DIFF
--- a/SoccerNoteApp.xcodeproj/project.pbxproj
+++ b/SoccerNoteApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */; };
 		5D14B37625565ADB002CA3D4 /* GameManagementTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */; };
+		5D14B396255BA6A1002CA3D4 /* GameManagementTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D14B395255BA6A1002CA3D4 /* GameManagementTableViewCell.xib */; };
 		5DAC50D3253DF01400F788BA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D2253DF01400F788BA /* AppDelegate.swift */; };
 		5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D4253DF01400F788BA /* SceneDelegate.swift */; };
 		5DAC50D7253DF01400F788BA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D6253DF01400F788BA /* ViewController.swift */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementViewController.swift; sourceTree = "<group>"; };
 		5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementTableViewCell.swift; sourceTree = "<group>"; };
+		5D14B395255BA6A1002CA3D4 /* GameManagementTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GameManagementTableViewCell.xib; sourceTree = "<group>"; };
 		5DAC50CF253DF01400F788BA /* SoccerNoteApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SoccerNoteApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DAC50D2253DF01400F788BA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5DAC50D4253DF01400F788BA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 				5DAC50D6253DF01400F788BA /* ViewController.swift */,
 				5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */,
 				5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */,
+				5D14B395255BA6A1002CA3D4 /* GameManagementTableViewCell.xib */,
 				5DAC50D8253DF01400F788BA /* Main.storyboard */,
 				5DAC50DB253DF01600F788BA /* Assets.xcassets */,
 				5DAC50DD253DF01600F788BA /* LaunchScreen.storyboard */,
@@ -239,6 +242,7 @@
 			files = (
 				5DAC50DF253DF01600F788BA /* LaunchScreen.storyboard in Resources */,
 				5DAC50DC253DF01600F788BA /* Assets.xcassets in Resources */,
+				5D14B396255BA6A1002CA3D4 /* GameManagementTableViewCell.xib in Resources */,
 				5DAC50DA253DF01400F788BA /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SoccerNoteApp/GameManagementTableViewCell.swift
+++ b/SoccerNoteApp/GameManagementTableViewCell.swift
@@ -9,6 +9,13 @@ import UIKit
 
 class GameManagementTableViewCell: UITableViewCell {
     
+    @IBOutlet weak var VSLabel: UILabel!
+    @IBOutlet weak var opponentTeamLabel: UILabel!
+    @IBOutlet weak var myScoreLabel: UILabel!
+    @IBOutlet weak var opponentScoreLabel: UILabel!
+    @IBOutlet weak var versusLabel: UILabel!
+    @IBOutlet weak var dateLabel: UILabel!
+    
     override func awakeFromNib() {
         super.awakeFromNib()
     }

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ZGl-po-9pN">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZGl-po-9pN" id="4eG-Yg-Dwe">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="-68.115942028985515" y="121.875"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -34,25 +35,25 @@
                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="9Wc-cd-EcR">
-                        <rect key="frame" x="285.5" y="7" width="93.5" height="36"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="9Wc-cd-EcR">
+                        <rect key="frame" x="271.5" y="7" width="107.5" height="36"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nhY-Li-2Pd">
-                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="36"/>
+                                <rect key="frame" x="0.0" y="0.0" width="30.5" height="36"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" systemColor="linkColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NdY-Yw-Juf">
-                                <rect key="frame" x="31.5" y="0.0" width="30.5" height="36"/>
+                                <rect key="frame" x="38.5" y="0.0" width="30.5" height="36"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" systemColor="linkColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIg-B5-WdD">
-                                <rect key="frame" x="74" y="0.0" width="19.5" height="36"/>
+                                <rect key="frame" x="77" y="0.0" width="30.5" height="36"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" systemColor="linkColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -80,4 +81,9 @@
             <point key="canvasLocation" x="-183.33333333333334" y="-3.683035714285714"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -9,7 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ZGl-po-9pN">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cellId" id="ZGl-po-9pN" customClass="GameManagementTableViewCell" customModule="SoccerNoteApp" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZGl-po-9pN" id="4eG-Yg-Dwe">

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -35,10 +35,10 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="日付" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ptj-GL-WcP">
-                        <rect key="frame" x="15" y="55" width="250" height="36"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020年11月12日" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ptj-GL-WcP">
+                        <rect key="frame" x="60" y="55" width="150" height="36"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="250" id="iCS-mK-qkW"/>
+                            <constraint firstAttribute="width" constant="150" id="iCS-mK-qkW"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -75,7 +75,7 @@
                     <constraint firstItem="nhY-Li-2Pd" firstAttribute="leading" secondItem="Dsg-El-719" secondAttribute="trailing" constant="15" id="fHK-IU-jXl"/>
                     <constraint firstItem="RIg-B5-WdD" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="goH-78-KNg"/>
                     <constraint firstItem="6kS-Uq-Fbf" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="15" id="jBx-w3-KAx"/>
-                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="15" id="leE-va-dar"/>
+                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="60" id="leE-va-dar"/>
                     <constraint firstItem="NdY-Yw-Juf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="nbj-5J-ZyT"/>
                 </constraints>
             </tableViewCellContentView>

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -9,87 +9,74 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cellId" rowHeight="198" id="ZGl-po-9pN" customClass="GameManagementTableViewCell" customModule="SoccerNoteApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="766" height="198"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cellId" rowHeight="190" id="ZGl-po-9pN" customClass="GameManagementTableViewCell" customModule="SoccerNoteApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="395" height="101"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZGl-po-9pN" id="4eG-Yg-Dwe">
-                <rect key="frame" x="0.0" y="0.0" width="766" height="198"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZGl-po-9pN" id="4eG-Yg-Dwe">
+                <rect key="frame" x="0.0" y="0.0" width="395" height="101"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6kS-Uq-Fbf">
-                        <rect key="frame" x="25" y="50" width="80" height="60"/>
+                        <rect key="frame" x="15" y="15" width="30" height="30"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="80" id="AbJ-ND-i6W"/>
-                            <constraint firstAttribute="height" constant="60" id="y2z-ou-KNN"/>
+                            <constraint firstAttribute="width" constant="30" id="AbJ-ND-i6W"/>
+                            <constraint firstAttribute="height" constant="30" id="y2z-ou-KNN"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="35"/>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                         <color key="textColor" red="0.11097417671621745" green="0.11365639636607935" blue="0.13223746827411165" alpha="0.80153039383561642" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="相手チーム" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dsg-El-719">
-                        <rect key="frame" x="125" y="45" width="330" height="57.5"/>
+                        <rect key="frame" x="55" y="12" width="180" height="30"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="330" id="AVZ-pW-cWR"/>
+                            <constraint firstAttribute="width" constant="180" id="nJ2-BJ-crk"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="48"/>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="25"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="日付" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ptj-GL-WcP">
-                        <rect key="frame" x="40" y="135" width="420" height="45"/>
+                        <rect key="frame" x="15" y="55" width="250" height="36"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="45" id="FtP-21-0sB"/>
-                            <constraint firstAttribute="width" constant="420" id="iCS-mK-qkW"/>
+                            <constraint firstAttribute="width" constant="250" id="iCS-mK-qkW"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nhY-Li-2Pd">
-                        <rect key="frame" x="485" y="45" width="60" height="60"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="60" id="Ncl-0b-8rv"/>
-                            <constraint firstAttribute="width" secondItem="nhY-Li-2Pd" secondAttribute="height" multiplier="1:1" id="r3D-oT-wrD"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="45"/>
+                        <rect key="frame" x="250" y="10" width="19.5" height="36"/>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIg-B5-WdD">
-                        <rect key="frame" x="645" y="45" width="60" height="60"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="60" id="SUW-VN-MDU"/>
-                            <constraint firstAttribute="width" secondItem="RIg-B5-WdD" secondAttribute="height" multiplier="1:1" id="hEm-EE-kRD"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="45"/>
+                        <rect key="frame" x="330" y="10" width="19.5" height="36"/>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NdY-Yw-Juf">
-                        <rect key="frame" x="565" y="45" width="60" height="60"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="60" id="Nad-Hj-7Yd"/>
-                            <constraint firstAttribute="width" secondItem="NdY-Yw-Juf" secondAttribute="height" multiplier="1:1" id="pPG-fG-RDk"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="40"/>
+                        <rect key="frame" x="284.5" y="10" width="30.5" height="36"/>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="RIg-B5-WdD" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="0HA-dh-z1I"/>
-                    <constraint firstItem="Dsg-El-719" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="2B7-fj-63g"/>
-                    <constraint firstItem="RIg-B5-WdD" firstAttribute="leading" secondItem="NdY-Yw-Juf" secondAttribute="trailing" constant="20" id="7ht-U5-Vu9"/>
-                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="D8S-z0-RUt"/>
-                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="leading" secondItem="nhY-Li-2Pd" secondAttribute="trailing" constant="20" id="HRQ-CR-NOa"/>
+                    <constraint firstItem="Dsg-El-719" firstAttribute="leading" secondItem="6kS-Uq-Fbf" secondAttribute="trailing" constant="10" id="EGQ-Xa-6Ge"/>
+                    <constraint firstItem="Dsg-El-719" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="12" id="GKS-BZ-4fQ"/>
+                    <constraint firstItem="RIg-B5-WdD" firstAttribute="leading" secondItem="NdY-Yw-Juf" secondAttribute="trailing" constant="15" id="HUs-sC-9NC"/>
+                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="JJd-Hk-K4M"/>
                     <constraint firstAttribute="bottom" secondItem="Ptj-GL-WcP" secondAttribute="bottom" constant="10" id="KSO-uF-BuS"/>
-                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="50" id="Q7F-Mo-Coe"/>
-                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="top" secondItem="6kS-Uq-Fbf" secondAttribute="bottom" constant="25" id="X5m-Dd-GSj"/>
-                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="25" id="jBx-w3-KAx"/>
-                    <constraint firstItem="Dsg-El-719" firstAttribute="leading" secondItem="6kS-Uq-Fbf" secondAttribute="trailing" constant="20" id="jIT-ga-baD"/>
-                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="40" id="leE-va-dar"/>
-                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="leading" secondItem="Dsg-El-719" secondAttribute="trailing" constant="30" id="nUQ-ww-awk"/>
-                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="tpQ-da-IIV"/>
+                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="15" id="Q7F-Mo-Coe"/>
+                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="leading" secondItem="nhY-Li-2Pd" secondAttribute="trailing" constant="15" id="SIl-P5-Q4g"/>
+                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="top" secondItem="6kS-Uq-Fbf" secondAttribute="bottom" constant="10" id="X5m-Dd-GSj"/>
+                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="leading" secondItem="Dsg-El-719" secondAttribute="trailing" constant="15" id="fHK-IU-jXl"/>
+                    <constraint firstItem="RIg-B5-WdD" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="goH-78-KNg"/>
+                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="15" id="jBx-w3-KAx"/>
+                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="15" id="leE-va-dar"/>
+                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="nbj-5J-ZyT"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
@@ -100,7 +87,7 @@
                 <outlet property="opponentTeamLabel" destination="Dsg-El-719" id="h0f-PM-dzl"/>
                 <outlet property="versusLabel" destination="NdY-Yw-Juf" id="ZGV-ap-oz4"/>
             </connections>
-            <point key="canvasLocation" x="186.95652173913044" y="189.50892857142856"/>
+            <point key="canvasLocation" x="-181.8840579710145" y="1.0044642857142856"/>
         </tableViewCell>
     </objects>
 </document>

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -17,66 +17,56 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6kS-Uq-Fbf">
-                        <rect key="frame" x="15" y="15" width="30" height="30"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="30" id="AbJ-ND-i6W"/>
-                            <constraint firstAttribute="height" constant="30" id="y2z-ou-KNN"/>
-                        </constraints>
+                        <rect key="frame" x="16" y="16" width="25.5" height="24"/>
                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                         <color key="textColor" red="0.11097417671621745" green="0.11365639636607935" blue="0.13223746827411165" alpha="0.80153039383561642" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="相手チーム" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dsg-El-719">
-                        <rect key="frame" x="55" y="12" width="180" height="30"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="180" id="nJ2-BJ-crk"/>
-                        </constraints>
+                        <rect key="frame" x="49.5" y="10" width="127" height="30"/>
                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="25"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020年11月12日" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ptj-GL-WcP">
-                        <rect key="frame" x="60" y="55" width="150" height="36"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="150" id="iCS-mK-qkW"/>
-                        </constraints>
+                        <rect key="frame" x="49.5" y="48" width="113.5" height="18"/>
                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nhY-Li-2Pd">
-                        <rect key="frame" x="250" y="10" width="19.5" height="36"/>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIg-B5-WdD">
-                        <rect key="frame" x="330" y="10" width="19.5" height="36"/>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NdY-Yw-Juf">
-                        <rect key="frame" x="284.5" y="10" width="30.5" height="36"/>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="9Wc-cd-EcR">
+                        <rect key="frame" x="285.5" y="7" width="93.5" height="36"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nhY-Li-2Pd">
+                                <rect key="frame" x="0.0" y="0.0" width="19.5" height="36"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NdY-Yw-Juf">
+                                <rect key="frame" x="31.5" y="0.0" width="30.5" height="36"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIg-B5-WdD">
+                                <rect key="frame" x="74" y="0.0" width="19.5" height="36"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Dsg-El-719" firstAttribute="leading" secondItem="6kS-Uq-Fbf" secondAttribute="trailing" constant="10" id="EGQ-Xa-6Ge"/>
-                    <constraint firstItem="Dsg-El-719" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="12" id="GKS-BZ-4fQ"/>
-                    <constraint firstItem="RIg-B5-WdD" firstAttribute="leading" secondItem="NdY-Yw-Juf" secondAttribute="trailing" constant="15" id="HUs-sC-9NC"/>
-                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="JJd-Hk-K4M"/>
-                    <constraint firstAttribute="bottom" secondItem="Ptj-GL-WcP" secondAttribute="bottom" constant="10" id="KSO-uF-BuS"/>
-                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="15" id="Q7F-Mo-Coe"/>
-                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="leading" secondItem="nhY-Li-2Pd" secondAttribute="trailing" constant="15" id="SIl-P5-Q4g"/>
-                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="top" secondItem="6kS-Uq-Fbf" secondAttribute="bottom" constant="10" id="X5m-Dd-GSj"/>
-                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="leading" secondItem="Dsg-El-719" secondAttribute="trailing" constant="15" id="fHK-IU-jXl"/>
-                    <constraint firstItem="RIg-B5-WdD" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="goH-78-KNg"/>
-                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="15" id="jBx-w3-KAx"/>
-                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="60" id="leE-va-dar"/>
-                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="10" id="nbj-5J-ZyT"/>
+                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="leading" secondItem="Dsg-El-719" secondAttribute="leading" id="13t-QK-MNh"/>
+                    <constraint firstAttribute="trailing" secondItem="9Wc-cd-EcR" secondAttribute="trailing" constant="16" id="H9V-zc-Iuc"/>
+                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="16" id="PVT-68-q3k"/>
+                    <constraint firstItem="Dsg-El-719" firstAttribute="leading" secondItem="6kS-Uq-Fbf" secondAttribute="trailing" constant="8" id="R6f-vK-VVO"/>
+                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="top" secondItem="Dsg-El-719" secondAttribute="bottom" constant="8" id="cSq-1x-TtV"/>
+                    <constraint firstItem="Dsg-El-719" firstAttribute="bottom" secondItem="6kS-Uq-Fbf" secondAttribute="bottom" id="eG6-B1-cA2"/>
+                    <constraint firstItem="9Wc-cd-EcR" firstAttribute="centerY" secondItem="Dsg-El-719" secondAttribute="centerY" id="s5F-t5-6et"/>
+                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="16" id="v3x-mB-8Qa"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
@@ -87,7 +77,7 @@
                 <outlet property="opponentTeamLabel" destination="Dsg-El-719" id="h0f-PM-dzl"/>
                 <outlet property="versusLabel" destination="NdY-Yw-Juf" id="ZGV-ap-oz4"/>
             </connections>
-            <point key="canvasLocation" x="-181.8840579710145" y="1.0044642857142856"/>
+            <point key="canvasLocation" x="-183.33333333333334" y="-3.683035714285714"/>
         </tableViewCell>
     </objects>
 </document>

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -92,6 +92,14 @@
                     <constraint firstItem="nhY-Li-2Pd" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="tpQ-da-IIV"/>
                 </constraints>
             </tableViewCellContentView>
+            <connections>
+                <outlet property="VSLabel" destination="6kS-Uq-Fbf" id="Sb5-av-kbi"/>
+                <outlet property="dateLabel" destination="Ptj-GL-WcP" id="iWn-Mu-uKA"/>
+                <outlet property="myScoreLabel" destination="nhY-Li-2Pd" id="Nzf-au-6uL"/>
+                <outlet property="opponentScoreLabel" destination="RIg-B5-WdD" id="lJe-U5-gyZ"/>
+                <outlet property="opponentTeamLabel" destination="Dsg-El-719" id="h0f-PM-dzl"/>
+                <outlet property="versusLabel" destination="NdY-Yw-Juf" id="ZGV-ap-oz4"/>
+            </connections>
             <point key="canvasLocation" x="186.95652173913044" y="189.50892857142856"/>
         </tableViewCell>
     </objects>

--- a/SoccerNoteApp/GameManagementTableViewCell.xib
+++ b/SoccerNoteApp/GameManagementTableViewCell.xib
@@ -9,14 +9,90 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cellId" id="ZGl-po-9pN" customClass="GameManagementTableViewCell" customModule="SoccerNoteApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cellId" rowHeight="198" id="ZGl-po-9pN" customClass="GameManagementTableViewCell" customModule="SoccerNoteApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="766" height="198"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZGl-po-9pN" id="4eG-Yg-Dwe">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZGl-po-9pN" id="4eG-Yg-Dwe">
+                <rect key="frame" x="0.0" y="0.0" width="766" height="198"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6kS-Uq-Fbf">
+                        <rect key="frame" x="25" y="50" width="80" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="80" id="AbJ-ND-i6W"/>
+                            <constraint firstAttribute="height" constant="60" id="y2z-ou-KNN"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="35"/>
+                        <color key="textColor" red="0.11097417671621745" green="0.11365639636607935" blue="0.13223746827411165" alpha="0.80153039383561642" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="相手チーム" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dsg-El-719">
+                        <rect key="frame" x="125" y="45" width="330" height="57.5"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="330" id="AVZ-pW-cWR"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="48"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="日付" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ptj-GL-WcP">
+                        <rect key="frame" x="40" y="135" width="420" height="45"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="45" id="FtP-21-0sB"/>
+                            <constraint firstAttribute="width" constant="420" id="iCS-mK-qkW"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nhY-Li-2Pd">
+                        <rect key="frame" x="485" y="45" width="60" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="60" id="Ncl-0b-8rv"/>
+                            <constraint firstAttribute="width" secondItem="nhY-Li-2Pd" secondAttribute="height" multiplier="1:1" id="r3D-oT-wrD"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="45"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIg-B5-WdD">
+                        <rect key="frame" x="645" y="45" width="60" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="60" id="SUW-VN-MDU"/>
+                            <constraint firstAttribute="width" secondItem="RIg-B5-WdD" secondAttribute="height" multiplier="1:1" id="hEm-EE-kRD"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="45"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NdY-Yw-Juf">
+                        <rect key="frame" x="565" y="45" width="60" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="60" id="Nad-Hj-7Yd"/>
+                            <constraint firstAttribute="width" secondItem="NdY-Yw-Juf" secondAttribute="height" multiplier="1:1" id="pPG-fG-RDk"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="40"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="RIg-B5-WdD" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="0HA-dh-z1I"/>
+                    <constraint firstItem="Dsg-El-719" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="2B7-fj-63g"/>
+                    <constraint firstItem="RIg-B5-WdD" firstAttribute="leading" secondItem="NdY-Yw-Juf" secondAttribute="trailing" constant="20" id="7ht-U5-Vu9"/>
+                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="D8S-z0-RUt"/>
+                    <constraint firstItem="NdY-Yw-Juf" firstAttribute="leading" secondItem="nhY-Li-2Pd" secondAttribute="trailing" constant="20" id="HRQ-CR-NOa"/>
+                    <constraint firstAttribute="bottom" secondItem="Ptj-GL-WcP" secondAttribute="bottom" constant="10" id="KSO-uF-BuS"/>
+                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="50" id="Q7F-Mo-Coe"/>
+                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="top" secondItem="6kS-Uq-Fbf" secondAttribute="bottom" constant="25" id="X5m-Dd-GSj"/>
+                    <constraint firstItem="6kS-Uq-Fbf" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="25" id="jBx-w3-KAx"/>
+                    <constraint firstItem="Dsg-El-719" firstAttribute="leading" secondItem="6kS-Uq-Fbf" secondAttribute="trailing" constant="20" id="jIT-ga-baD"/>
+                    <constraint firstItem="Ptj-GL-WcP" firstAttribute="leading" secondItem="4eG-Yg-Dwe" secondAttribute="leading" constant="40" id="leE-va-dar"/>
+                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="leading" secondItem="Dsg-El-719" secondAttribute="trailing" constant="30" id="nUQ-ww-awk"/>
+                    <constraint firstItem="nhY-Li-2Pd" firstAttribute="top" secondItem="4eG-Yg-Dwe" secondAttribute="top" constant="45" id="tpQ-da-IIV"/>
+                </constraints>
             </tableViewCellContentView>
-            <point key="canvasLocation" x="-68.115942028985515" y="121.875"/>
+            <point key="canvasLocation" x="186.95652173913044" y="189.50892857142856"/>
         </tableViewCell>
     </objects>
 </document>

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 class GameManagementViewController: UIViewController {
     
-    //この後TableViewCellのXibファイルとの紐付けに使います
     private let cellId = "cellId"
     
     @IBOutlet weak var gameManagementTableView: UITableView!
@@ -19,9 +18,8 @@ class GameManagementViewController: UIViewController {
         
         gameManagementTableView.delegate = self
         gameManagementTableView.dataSource = self
+        gameManagementTableView.register(UINib(nibName: "GameManagementTableViewCell", bundle: nil), forCellReuseIdentifier: cellId)
         
-        //仮の実装（この後TableViewCellとの紐付けの際削除する予定）
-        gameManagementTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
     }
     
 }


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-TableViewCell https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合管理画面 Xib TableViewCell: チーム・スコア・日付  実装

**概要**
試合管理画面のTableViewCellを実装
CellにAutoLayoutでLabelの貼り付け
TableViewとの紐付け

**レビューで見て欲しいポイント**
AutoLayoutが上手くできているか、UIに関して。
commitの名前に自信がないです。例えばこれならこう言う名前が良いかなと言ったアドバイスをもう一度頂けないでしょうか。

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741

**補足**
後から気づいての修正や追記の余計なcommitが増えてしまいました。すいません。