### PR TITLE
NavigationController実装

### DIFF
--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -31,8 +31,13 @@
                             <constraint firstItem="Dte-cP-JJe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="ri9-wb-wRv"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="HL9-jX-8jB"/>
+                    <navigationItem key="navigationItem" id="HL9-jX-8jB">
+                        <barButtonItem key="rightBarButtonItem" style="plain" systemItem="add" id="tMa-K9-bVj">
+                            <color key="tintColor" red="0.092434234917163849" green="0.46455097198486328" blue="0.58892422914505005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
+                        <outlet property="gameAddButton" destination="tMa-K9-bVj" id="C7s-Um-wN3"/>
                         <outlet property="gameManagementTableView" destination="Dte-cP-JJe" id="KlS-Te-5ii"/>
                     </connections>
                 </viewController>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Qxw-je-PRi">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dte-cP-JJe">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -31,11 +31,30 @@
                             <constraint firstItem="Dte-cP-JJe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="ri9-wb-wRv"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="HL9-jX-8jB"/>
                     <connections>
                         <outlet property="gameManagementTableView" destination="Dte-cP-JJe" id="KlS-Te-5ii"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1050.7246376811595" y="110.49107142857143"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="pxE-C4-7s9">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Qxw-je-PRi" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yIJ-7I-Aar">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="fP3-3u-dhp"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6gU-Zb-JUV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="140.57971014492756" y="110.49107142857143"/>
         </scene>

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -18,7 +18,11 @@ class GameManagementViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        title = "試合管理"
+        func headerTitle() {
+            title = "試合管理"
+        }
+        
+        headerTitle()
         
         gameManagementTableView.delegate = self
         gameManagementTableView.dataSource = self
@@ -26,7 +30,7 @@ class GameManagementViewController: UIViewController {
         //仮の実装（この後TableViewCellとの紐付けの際削除する予定）
         gameManagementTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
     }
-    
+   
 }
 
 extension GameManagementViewController: UITableViewDelegate,UITableViewDataSource {

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -15,7 +15,6 @@ class GameManagementViewController: UIViewController {
     @IBOutlet weak var gameManagementTableView: UITableView!
     @IBOutlet weak var gameAddButton: UIBarButtonItem!
     
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -13,6 +13,8 @@ class GameManagementViewController: UIViewController {
     private let cellId = "cellId"
     
     @IBOutlet weak var gameManagementTableView: UITableView!
+    @IBOutlet weak var gameAddButton: UIBarButtonItem!
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -18,10 +18,6 @@ class GameManagementViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        func headerTitle() {
-            title = "試合管理"
-        }
-        
         headerTitle()
         
         gameManagementTableView.delegate = self
@@ -29,6 +25,10 @@ class GameManagementViewController: UIViewController {
         
         //仮の実装（この後TableViewCellとの紐付けの際削除する予定）
         gameManagementTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
+    }
+    
+    func headerTitle() {
+        title = "試合管理"
     }
    
 }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -17,6 +17,8 @@ class GameManagementViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        title = "試合管理"
+        
         gameManagementTableView.delegate = self
         gameManagementTableView.dataSource = self
         


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-NavigationController https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合管理画面　NavigationController実装

**概要**
NavigationControllerを実装しました。
登録画面に遷移するボタン（Add）を実装しました。

**レビューで見て欲しいポイント**
プロトタイプでは、ボタンを「登録」にしていたんですけど、「＋」のAddボタンにしました。
この変更は問題ないでしょうか？

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741