### PR TITLE
試合登録画面　ViewController 実装

### DIFF
--- a/SoccerNoteApp.xcodeproj/project.pbxproj
+++ b/SoccerNoteApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5DAC50DF253DF01600F788BA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5DAC50DD253DF01600F788BA /* LaunchScreen.storyboard */; };
 		5DAC50EA253DF01600F788BA /* SoccerNoteAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50E9253DF01600F788BA /* SoccerNoteAppTests.swift */; };
 		5DAC50F5253DF01600F788BA /* SoccerNoteAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50F4253DF01600F788BA /* SoccerNoteAppUITests.swift */; };
+		5DEB73B6255FA1A900FD06E3 /* GameRegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DEB73B5255FA1A900FD06E3 /* GameRegisterViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		5DAC50F0253DF01600F788BA /* SoccerNoteAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SoccerNoteAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DAC50F4253DF01600F788BA /* SoccerNoteAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoccerNoteAppUITests.swift; sourceTree = "<group>"; };
 		5DAC50F6253DF01600F788BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5DEB73B5255FA1A900FD06E3 /* GameRegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameRegisterViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				5DAC50D6253DF01400F788BA /* ViewController.swift */,
 				5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */,
 				5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */,
+				5DEB73B5255FA1A900FD06E3 /* GameRegisterViewController.swift */,
 				5DAC50D8253DF01400F788BA /* Main.storyboard */,
 				5DAC50DB253DF01600F788BA /* Assets.xcassets */,
 				5DAC50DD253DF01600F788BA /* LaunchScreen.storyboard */,
@@ -268,6 +271,7 @@
 				5DAC50D3253DF01400F788BA /* AppDelegate.swift in Sources */,
 				5D14B37625565ADB002CA3D4 /* GameManagementTableViewCell.swift in Sources */,
 				5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */,
+				5DEB73B6255FA1A900FD06E3 /* GameRegisterViewController.swift in Sources */,
 				5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -45,6 +45,22 @@
             </objects>
             <point key="canvasLocation" x="1050.7246376811595" y="110.49107142857143"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="Ukc-rz-EO8">
+            <objects>
+                <viewController id="rP5-fx-GU0" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="qNZ-Id-jpi">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lFU-aH-rS5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1913" y="110"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="pxE-C4-7s9">
             <objects>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -39,6 +39,7 @@
                     <connections>
                         <outlet property="gameAddButton" destination="tMa-K9-bVj" id="C7s-Um-wN3"/>
                         <outlet property="gameManagementTableView" destination="Dte-cP-JJe" id="KlS-Te-5ii"/>
+                        <segue destination="rP5-fx-GU0" kind="show" id="osG-eI-CUr"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -45,10 +45,10 @@
             </objects>
             <point key="canvasLocation" x="1050.7246376811595" y="110.49107142857143"/>
         </scene>
-        <!--View Controller-->
+        <!--Game Register View Controller-->
         <scene sceneID="Ukc-rz-EO8">
             <objects>
-                <viewController id="rP5-fx-GU0" sceneMemberID="viewController">
+                <viewController id="rP5-fx-GU0" customClass="GameRegisterViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qNZ-Id-jpi">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -1,0 +1,29 @@
+//
+//  GameRegisterViewController.swift
+//  SoccerNoteApp
+//
+//  Created by hideto c. on 2020/11/14.
+//
+
+import UIKit
+
+class GameRegisterViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-GameRegister-ViewController https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合登録画面 ViewController 実装

**概要**
試合登録画面のViewControllerを実装しました。
試合登録画面のファイルを作成し、紐付けまでしました。
試合管理画面と試合登録画面の紐付けもしました。

**レビューで見て欲しいポイント**
実装方法に問題はないか。

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741
