### PR TITLE
試合管理画面->試合登録画面　画面遷移 実装　Navigation UI 変更

### DIFF
--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -34,12 +34,14 @@
                     <navigationItem key="navigationItem" id="HL9-jX-8jB">
                         <barButtonItem key="rightBarButtonItem" style="plain" systemItem="add" id="tMa-K9-bVj">
                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <segue destination="rP5-fx-GU0" kind="show" id="3Kv-jA-KiH"/>
+                            </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="gameAddButton" destination="tMa-K9-bVj" id="C7s-Um-wN3"/>
                         <outlet property="gameManagementTableView" destination="Dte-cP-JJe" id="KlS-Te-5ii"/>
-                        <segue destination="rP5-fx-GU0" kind="show" id="osG-eI-CUr"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -33,7 +33,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="HL9-jX-8jB">
                         <barButtonItem key="rightBarButtonItem" style="plain" systemItem="add" id="tMa-K9-bVj">
-                            <color key="tintColor" red="0.092434234917163849" green="0.46455097198486328" blue="0.58892422914505005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
@@ -70,6 +70,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yIJ-7I-Aar">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="barTintColor" red="0.14693497512197692" green="0.34631367410427921" blue="0.49445108259994974" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -11,6 +11,9 @@ class GameRegisterViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        navigationItem.title = "試合"
+        self.navigationController?.navigationBar.tintColor = UIColor.white
 
     }
     

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -12,11 +12,11 @@ class GameRegisterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NavigationBar()
+        setupNavigationBar()
 
     }
     
-    func NavigationBar() {
+    func setupNavigationBar() {
         navigationItem.title = "試合"
         self.navigationController?.navigationBar.tintColor = UIColor.white
     }

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -12,18 +12,6 @@ class GameRegisterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
-}
+ }

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -12,9 +12,13 @@ class GameRegisterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        NavigationBar()
+
+    }
+    
+    func NavigationBar() {
         navigationItem.title = "試合"
         self.navigationController?.navigationBar.tintColor = UIColor.white
-
     }
     
  }


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-Navigation-modification https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合管理画面→試合登録画面 画面遷移

**概要**
試合管理画面から試合登録画面への画面遷移を実装しました。
Navigationの背景色、BackButtonの色、titleの名前を追加実装しました。

**レビューで見て欲しいポイント**
試合管理画面の時と違って、titleの名前のコードの書き方を変えたのですがこの書き方は良くないですか？

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741

**補足**
画面遷移とNavigationのUI変更を違うブランチでやろうと思っていたんですけど、一緒にしてしまいました。
レビューしづらかったらすいません。
