### PR TITLE
ダークモード非対応に設定

### DIFF
--- a/SoccerNoteApp/Info.plist
+++ b/SoccerNoteApp/Info.plist
@@ -62,5 +62,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UI User Interface Style</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/UserInterfaceStyle https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
ダークモード非対応

**概要**
Info.plistでUIUserInterfaceStyleキーを追加し、Lightにしてダークモード非対応に設定しました。

**レビューで見て欲しいポイント**
自分のビルドでは、上手く設定できていたのですが確認お願いしたいです。

**参考URL**
https://qiita.com/hiroyuki7/items/161881c38bd6e19fd396
https://qiita.com/tsuzuki817/items/e6252c1ae1f1ab0502f2

**実機build/期待通りの挙動をするか**
OK 

※UI変更した場合のみ記述

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741