### PR TITLE
UIDatePicker実装

### DIFF
--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -56,9 +56,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
-                                <rect key="frame" x="0.0" y="88" width="414" height="50"/>
+                            <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
+                                <rect key="frame" x="8" y="98" width="397" height="50"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -55,14 +55,23 @@
                     <view key="view" contentMode="scaleToFill" id="qNZ-Id-jpi">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
+                                <rect key="frame" x="0.0" y="88" width="414" height="50"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            </datePicker>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>
+                    <connections>
+                        <outlet property="datePicker" destination="3Kg-3u-GOy" id="FcG-V2-kZ1"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lFU-aH-rS5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1913" y="110"/>
+            <point key="canvasLocation" x="1911.594202898551" y="109.82142857142857"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="pxE-C4-7s9">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -74,9 +74,6 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>
-                    <connections>
-                        <outlet property="datePicker" destination="3Kg-3u-GOy" id="FcG-V2-kZ1"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lFU-aH-rS5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -60,7 +60,7 @@
                                 <rect key="frame" x="8" y="96" width="398" height="40"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="199:20" id="EHs-Qr-KGF"/>
+                                    <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="10:1" id="EHs-Qr-KGF"/>
                                 </constraints>
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -56,15 +56,22 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
-                                <rect key="frame" x="8" y="98" width="397" height="50"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
+                                <rect key="frame" x="8" y="96" width="398" height="40"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="199:20" id="EHs-Qr-KGF"/>
+                                </constraints>
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="8" id="595-Px-JP6"/>
+                            <constraint firstItem="SjI-ID-hWl" firstAttribute="trailing" secondItem="3Kg-3u-GOy" secondAttribute="trailing" constant="8" id="buk-Sa-aHG"/>
+                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="top" secondItem="SjI-ID-hWl" secondAttribute="top" constant="8" id="xy0-0r-vrY"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>
                     <connections>

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 class GameRegisterViewController: UIViewController {
-
+    
+    @IBOutlet weak var datePicker: UIDatePicker!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -9,8 +9,6 @@ import UIKit
 
 class GameRegisterViewController: UIViewController {
     
-    @IBOutlet weak var datePicker: UIDatePicker!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-DatePicker https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合登録画面　DatePicker実装

**概要**
試合登録画面に日付を選択するDatePickerを実装しました。

**レビューで見て欲しいポイント**
DatePickerの実装方法に問題はないでしょうか。
カスタマイズをするのに、コードでもできたのですが簡単にstoryboardでやりました。
コードの方が良いのかどっちでも良いのかアドバイス頂けたらと思います。

**参考URL**
https://dev.classmethod.jp/articles/ios-14-ui-date-picker-style/
https://qiita.com/kj_trsm/items/a53b0b3f7e1bc7c06106

**実機build/期待通りの挙動をするか**
OK 

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741

**補足**
DatePickerをコードに最初紐付けをしていたのですが、消しました。
いずれFierbase接続など、データ管理する時に必要になるかもしれないんですけど、ややこしくならないようにまたその時に紐付けをしようと思っています。