### PR TITLE
試合登録画面　StackView実装

### DIFF
--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -64,7 +64,7 @@
                                 </constraints>
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1" userLabel="Game Data Stack View">
                                 <rect key="frame" x="16" y="150" width="382" height="77"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT" userLabel="Team Stack View">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -120,8 +120,8 @@
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>
                     <connections>
-                        <outlet property="myScoreLabel" destination="i39-ld-Wyn" id="JNe-B1-RpD"/>
-                        <outlet property="opponentScoreLabel" destination="u5l-uM-MaY" id="bXn-jv-cuT"/>
+                        <outlet property="myScoreTextField" destination="i39-ld-Wyn" id="Z4K-Bg-IQZ"/>
+                        <outlet property="opponentScoreTextField" destination="u5l-uM-MaY" id="q7N-1o-FuB"/>
                         <outlet property="teamTextField" destination="HMf-mO-THt" id="D0g-D1-TOC"/>
                     </connections>
                 </viewController>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -67,7 +67,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1">
                                 <rect key="frame" x="16" y="150" width="382" height="77"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT">
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT" userLabel="Team Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O90-28-gsI">
@@ -83,7 +83,7 @@
                                             </textField>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-jX-70f">
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-jX-70f" userLabel="Score Stack View">
                                         <rect key="frame" x="0.0" y="46" width="382" height="31"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i39-ld-Wyn">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -57,7 +57,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
-                                <rect key="frame" x="8" y="96" width="398" height="40"/>
+                                <rect key="frame" x="16" y="96" width="382" height="38"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="10:1" id="EHs-Qr-KGF"/>
@@ -65,61 +65,57 @@
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1">
-                                <rect key="frame" x="24" y="152" width="366" height="81"/>
+                                <rect key="frame" x="16" y="150" width="382" height="77"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT">
-                                        <rect key="frame" x="0.0" y="0.0" width="366" height="33"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O90-28-gsI">
-                                                <rect key="frame" x="0.0" y="0.0" width="32.5" height="33"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="32.5" height="31"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HMf-mO-THt">
-                                                <rect key="frame" x="48.5" y="0.0" width="317.5" height="33"/>
+                                                <rect key="frame" x="48.5" y="0.0" width="333.5" height="31"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-jX-70f">
-                                        <rect key="frame" x="0.0" y="48" width="366" height="33"/>
+                                        <rect key="frame" x="0.0" y="46" width="382" height="31"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i39-ld-Wyn">
-                                                <rect key="frame" x="0.0" y="0.0" width="138" height="33"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="143.5" height="31"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="17j-g8-Pin">
-                                                <rect key="frame" x="114" y="0.0" width="138" height="33"/>
+                                                <rect key="frame" x="119.5" y="0.0" width="143" height="31"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u5l-uM-MaY">
-                                                <rect key="frame" x="228" y="0.0" width="138" height="33"/>
+                                                <rect key="frame" x="238.5" y="0.0" width="143.5" height="31"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="1Pj-GZ-yV1" secondAttribute="height" multiplier="9:2" id="P2Z-FT-8cN"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="1Pj-GZ-yV1" firstAttribute="top" secondItem="3Kg-3u-GOy" secondAttribute="bottom" constant="16" id="22G-0u-ZkS"/>
-                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="8" id="K5a-4C-cpV"/>
-                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="24" id="RaH-e3-hjU"/>
+                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="16" id="K5a-4C-cpV"/>
                             <constraint firstItem="1Pj-GZ-yV1" firstAttribute="centerX" secondItem="3Kg-3u-GOy" secondAttribute="centerX" id="V1H-fV-RvW"/>
+                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="width" id="Wuz-Vo-a10"/>
                             <constraint firstItem="3Kg-3u-GOy" firstAttribute="top" secondItem="SjI-ID-hWl" secondAttribute="top" constant="8" id="gId-oO-yYT"/>
-                            <constraint firstItem="SjI-ID-hWl" firstAttribute="trailing" secondItem="1Pj-GZ-yV1" secondAttribute="trailing" constant="24" id="imp-0u-HiN"/>
-                            <constraint firstAttribute="trailing" secondItem="3Kg-3u-GOy" secondAttribute="trailing" constant="8" id="niy-wG-4k3"/>
+                            <constraint firstAttribute="trailing" secondItem="3Kg-3u-GOy" secondAttribute="trailing" constant="16" id="niy-wG-4k3"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -123,6 +123,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>
+                    <connections>
+                        <outlet property="myScoreLabel" destination="i39-ld-Wyn" id="JNe-B1-RpD"/>
+                        <outlet property="opponentScoreLabel" destination="u5l-uM-MaY" id="bXn-jv-cuT"/>
+                        <outlet property="teamTextField" destination="HMf-mO-THt" id="D0g-D1-TOC"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lFU-aH-rS5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -64,13 +64,62 @@
                                 </constraints>
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1">
+                                <rect key="frame" x="24" y="152" width="366" height="81"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT">
+                                        <rect key="frame" x="0.0" y="0.0" width="366" height="33"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O90-28-gsI">
+                                                <rect key="frame" x="0.0" y="0.0" width="32.5" height="33"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HMf-mO-THt">
+                                                <rect key="frame" x="48.5" y="0.0" width="317.5" height="33"/>
+                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-jX-70f">
+                                        <rect key="frame" x="0.0" y="48" width="366" height="33"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i39-ld-Wyn">
+                                                <rect key="frame" x="0.0" y="0.0" width="138" height="33"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="17j-g8-Pin">
+                                                <rect key="frame" x="114" y="0.0" width="138" height="33"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u5l-uM-MaY">
+                                                <rect key="frame" x="228" y="0.0" width="138" height="33"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="1Pj-GZ-yV1" secondAttribute="height" multiplier="9:2" id="P2Z-FT-8cN"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="8" id="595-Px-JP6"/>
-                            <constraint firstItem="SjI-ID-hWl" firstAttribute="trailing" secondItem="3Kg-3u-GOy" secondAttribute="trailing" constant="8" id="buk-Sa-aHG"/>
-                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="top" secondItem="SjI-ID-hWl" secondAttribute="top" constant="8" id="xy0-0r-vrY"/>
+                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="top" secondItem="3Kg-3u-GOy" secondAttribute="bottom" constant="16" id="22G-0u-ZkS"/>
+                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="8" id="K5a-4C-cpV"/>
+                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="24" id="RaH-e3-hjU"/>
+                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="centerX" secondItem="3Kg-3u-GOy" secondAttribute="centerX" id="V1H-fV-RvW"/>
+                            <constraint firstItem="3Kg-3u-GOy" firstAttribute="top" secondItem="SjI-ID-hWl" secondAttribute="top" constant="8" id="gId-oO-yYT"/>
+                            <constraint firstItem="SjI-ID-hWl" firstAttribute="trailing" secondItem="1Pj-GZ-yV1" secondAttribute="trailing" constant="24" id="imp-0u-HiN"/>
+                            <constraint firstAttribute="trailing" secondItem="3Kg-3u-GOy" secondAttribute="trailing" constant="8" id="niy-wG-4k3"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 
 class GameRegisterViewController: UIViewController {
     
+    @IBOutlet weak var teamTextField: UITextField!
+    @IBOutlet weak var myScoreLabel: UITextField!
+    @IBOutlet weak var opponentScoreLabel: UITextField!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class GameRegisterViewController: UIViewController {
+class GameRegisterViewController: UIViewController,UITextFieldDelegate {
     
     @IBOutlet weak var teamTextField: UITextField!
     @IBOutlet weak var myScoreLabel: UITextField!
@@ -16,8 +16,20 @@ class GameRegisterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        teamTextField.delegate = self
+        myScoreLabel.delegate = self
+        opponentScoreLabel.delegate = self
+        
         setupNavigationBar()
 
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
     }
     
     func setupNavigationBar() {

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -20,6 +20,9 @@ class GameRegisterViewController: UIViewController,UITextFieldDelegate {
         myScoreLabel.delegate = self
         opponentScoreLabel.delegate = self
         
+        self.myScoreLabel.keyboardType = UIKeyboardType.numberPad
+        self.opponentScoreLabel.keyboardType = UIKeyboardType.numberPad
+        
         setupNavigationBar()
 
     }

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -10,18 +10,18 @@ import UIKit
 class GameRegisterViewController: UIViewController,UITextFieldDelegate {
     
     @IBOutlet weak var teamTextField: UITextField!
-    @IBOutlet weak var myScoreLabel: UITextField!
-    @IBOutlet weak var opponentScoreLabel: UITextField!
+    @IBOutlet weak var myScoreTextField: UITextField!
+    @IBOutlet weak var opponentScoreTextField: UITextField!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         teamTextField.delegate = self
-        myScoreLabel.delegate = self
-        opponentScoreLabel.delegate = self
+        myScoreTextField.delegate = self
+        opponentScoreTextField.delegate = self
         
-        self.myScoreLabel.keyboardType = UIKeyboardType.numberPad
-        self.opponentScoreLabel.keyboardType = UIKeyboardType.numberPad
+        self.myScoreTextField.keyboardType = UIKeyboardType.numberPad
+        self.opponentScoreTextField.keyboardType = UIKeyboardType.numberPad
         
         setupNavigationBar()
 

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -20,11 +20,15 @@ class GameRegisterViewController: UIViewController,UITextFieldDelegate {
         myScoreTextField.delegate = self
         opponentScoreTextField.delegate = self
         
-        self.myScoreTextField.keyboardType = UIKeyboardType.numberPad
-        self.opponentScoreTextField.keyboardType = UIKeyboardType.numberPad
+        setupKeyboard()
         
         setupNavigationBar()
 
+    }
+    
+    func setupKeyboard() {
+        self.myScoreTextField.keyboardType = UIKeyboardType.numberPad
+        self.opponentScoreTextField.keyboardType = UIKeyboardType.numberPad
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-StackView https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合登録画面 チーム・スコア: StackView(TextField, Label) 実装

**概要**
試合登録画面のチーム・スコアのUIにStackViewを実装し、その中にTextFeildとLabelを実装しました。
キーボードをカスタマイズし、Return or 画面タップでキーボードを閉じる実装とスコアのキーボードを数字のみにする実装をしました。

**レビューで見て欲しいポイント**
AutoLayoutでUI的に問題ないか。
AutoLayoutの制約方法に問題ないか。
もう少しこうした方がいいと言ったアドバイスあれば頂きたいです。

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741

**補足**
ここでは関係ないのですが、実機ビルドした時にダークモード非対応がやっぱりできていませんでした。笑
また後々に修正したいと思います。