### PR TITLE
試合登録画面 登録ボタン実装

### DIFF
--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -64,7 +64,7 @@
                                         <barButtonItem key="leftBarButtonItem" image="chevron.backward" catalog="system" style="plain" id="miu-Z4-Vhx">
                                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <connections>
-                                                <action selector="backToGameManagement:" destination="rP5-fx-GU0" id="lyL-xZ-vdh"/>
+                                                <action selector="didTapBackButton:" destination="rP5-fx-GU0" id="NW4-nr-UIS"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -190,7 +190,7 @@
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <connections>
-                                    <action selector="registerButtonToBack:" destination="rP5-fx-GU0" eventType="touchUpInside" id="LtR-cF-hex"/>
+                                    <action selector="didTapRegisterButton:" destination="rP5-fx-GU0" eventType="touchUpInside" id="VWe-V5-eFb"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -57,7 +57,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PM2-Sh-RwO">
-                                <rect key="frame" x="0.0" y="44" width="375" height="48"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="54"/>
                                 <color key="barTintColor" red="0.1469349751" green="0.34631367410000002" blue="0.49445108259999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <items>
                                     <navigationItem title="試合" id="HTE-mg-BDj">
@@ -71,7 +71,7 @@
                                 </items>
                             </navigationBar>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
-                                <rect key="frame" x="16" y="100" width="343" height="34.333333333333343"/>
+                                <rect key="frame" x="16" y="106" width="343" height="34.333333333333343"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="10:1" id="EHs-Qr-KGF"/>
@@ -79,7 +79,7 @@
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1" userLabel="Game Data Stack View">
-                                <rect key="frame" x="16" y="142.33333333333334" width="343" height="72.666666666666657"/>
+                                <rect key="frame" x="16" y="148.33333333333334" width="343" height="72.666666666666657"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT" userLabel="Team Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
@@ -121,7 +121,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="3lk-kU-cIY" userLabel="Impression Stack View">
-                                <rect key="frame" x="16" y="223" width="343" height="465"/>
+                                <rect key="frame" x="16" y="229" width="343" height="465"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aX0-Y7-CQv" userLabel="First Half Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="148.33333333333334"/>
@@ -179,12 +179,22 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kJn-No-Q5j">
+                                <rect key="frame" x="139.66666666666666" y="718" width="96" height="36"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="kJn-No-Q5j" secondAttribute="height" multiplier="8:3" id="KCl-4b-Hv7"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
+                                <state key="normal" title="Button"/>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="PM2-Sh-RwO" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" id="0jb-u7-PX1"/>
+                            <constraint firstItem="SjI-ID-hWl" firstAttribute="bottom" secondItem="kJn-No-Q5j" secondAttribute="bottom" constant="24" id="18J-UI-WiC"/>
                             <constraint firstItem="1Pj-GZ-yV1" firstAttribute="top" secondItem="3Kg-3u-GOy" secondAttribute="bottom" constant="8" id="22G-0u-ZkS"/>
+                            <constraint firstItem="kJn-No-Q5j" firstAttribute="centerX" secondItem="3lk-kU-cIY" secondAttribute="centerX" id="435-B2-XnJ"/>
                             <constraint firstItem="PM2-Sh-RwO" firstAttribute="trailing" secondItem="SjI-ID-hWl" secondAttribute="trailing" id="6an-Pl-Zxn"/>
                             <constraint firstItem="3Kg-3u-GOy" firstAttribute="top" secondItem="PM2-Sh-RwO" secondAttribute="bottom" constant="8" id="IjR-a6-DDb"/>
                             <constraint firstItem="3Kg-3u-GOy" firstAttribute="leading" secondItem="SjI-ID-hWl" secondAttribute="leading" constant="16" id="K5a-4C-cpV"/>
@@ -194,8 +204,8 @@
                             <constraint firstItem="1Pj-GZ-yV1" firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="width" id="Wuz-Vo-a10"/>
                             <constraint firstItem="3lk-kU-cIY" firstAttribute="width" secondItem="1Pj-GZ-yV1" secondAttribute="width" id="ild-0L-bXW"/>
                             <constraint firstAttribute="trailing" secondItem="3Kg-3u-GOy" secondAttribute="trailing" constant="16" id="niy-wG-4k3"/>
+                            <constraint firstItem="kJn-No-Q5j" firstAttribute="top" secondItem="3lk-kU-cIY" secondAttribute="bottom" constant="24" id="rOE-ck-QQa"/>
                             <constraint firstItem="PM2-Sh-RwO" firstAttribute="top" secondItem="SjI-ID-hWl" secondAttribute="top" id="wx8-90-QtE"/>
-                            <constraint firstItem="SjI-ID-hWl" firstAttribute="bottom" secondItem="3lk-kU-cIY" secondAttribute="bottom" constant="90" id="yQI-1k-9Vi"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Orh-nQ-m2s"/>
@@ -211,7 +221,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lFU-aH-rS5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1911.594202898551" y="109.82142857142857"/>
+            <point key="canvasLocation" x="1911.2" y="109.35960591133005"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="pxE-C4-7s9">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Qxw-je-PRi">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Qxw-je-PRi">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,11 +14,11 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="GameManagementViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dte-cP-JJe">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="690"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -53,11 +53,11 @@
             <objects>
                 <viewController modalPresentationStyle="fullScreen" id="rP5-fx-GU0" customClass="GameRegisterViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qNZ-Id-jpi">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PM2-Sh-RwO">
-                                <rect key="frame" x="0.0" y="44" width="414" height="128.5"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="48"/>
                                 <color key="barTintColor" red="0.1469349751" green="0.34631367410000002" blue="0.49445108259999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <items>
                                     <navigationItem title="試合" id="HTE-mg-BDj">
@@ -71,7 +71,7 @@
                                 </items>
                             </navigationBar>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
-                                <rect key="frame" x="16" y="180.5" width="382" height="38"/>
+                                <rect key="frame" x="16" y="100" width="343" height="34.333333333333343"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="10:1" id="EHs-Qr-KGF"/>
@@ -79,40 +79,40 @@
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1" userLabel="Game Data Stack View">
-                                <rect key="frame" x="16" y="226.5" width="382" height="72"/>
+                                <rect key="frame" x="16" y="142.33333333333334" width="343" height="72.666666666666657"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT" userLabel="Team Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="31"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O90-28-gsI">
-                                                <rect key="frame" x="0.0" y="0.0" width="32.5" height="31"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="32.333333333333336" height="31.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HMf-mO-THt">
-                                                <rect key="frame" x="48.5" y="0.0" width="333.5" height="31"/>
+                                                <rect key="frame" x="48.333333333333343" y="0.0" width="294.66666666666663" height="31.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-jX-70f" userLabel="Score Stack View">
-                                        <rect key="frame" x="0.0" y="41" width="382" height="31"/>
+                                        <rect key="frame" x="0.0" y="41.333333333333314" width="343" height="31.333333333333329"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i39-ld-Wyn">
-                                                <rect key="frame" x="0.0" y="0.0" width="143.5" height="31"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="31.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="17j-g8-Pin">
-                                                <rect key="frame" x="119.5" y="0.0" width="143" height="31"/>
+                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u5l-uM-MaY">
-                                                <rect key="frame" x="238.5" y="0.0" width="143.5" height="31"/>
+                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
@@ -121,19 +121,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="3lk-kU-cIY" userLabel="Impression Stack View">
-                                <rect key="frame" x="16" y="306.5" width="382" height="465.5"/>
+                                <rect key="frame" x="16" y="223" width="343" height="465"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aX0-Y7-CQv" userLabel="First Half Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="148.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="148.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O1G-XQ-wZg">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ZUY-7G-0EB">
-                                                <rect key="frame" x="0.0" y="20.5" width="382" height="128"/>
+                                                <rect key="frame" x="0.0" y="20.333333333333343" width="343" height="128"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -142,16 +142,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zFD-fJ-wZx" userLabel="Sencond Half Stack View">
-                                        <rect key="frame" x="0.0" y="158.5" width="382" height="148.5"/>
+                                        <rect key="frame" x="0.0" y="158.33333333333331" width="343" height="148.33333333333331"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hfB-Ml-wpG">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="AM9-Fv-Aa6">
-                                                <rect key="frame" x="0.0" y="20.5" width="382" height="128"/>
+                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="128"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -160,16 +160,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="syE-lO-Eli" userLabel="All Stack View">
-                                        <rect key="frame" x="0.0" y="317" width="382" height="148.5"/>
+                                        <rect key="frame" x="0.0" y="316.66666666666663" width="343" height="148.33333333333337"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uka-XJ-nVH">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3gj-Dt-Bve">
-                                                <rect key="frame" x="0.0" y="20.5" width="382" height="128"/>
+                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="128"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -219,7 +219,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Qxw-je-PRi" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yIJ-7I-Aar">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.14693497512197692" green="0.34631367410427921" blue="0.49445108259994974" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--Game Management View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="GameManagementViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="gameManagement" id="BYZ-38-t0r" customClass="GameManagementViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -189,6 +189,9 @@
                                 <state key="normal" title="登録">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
+                                <connections>
+                                    <action selector="registerButtonToBack:" destination="rP5-fx-GU0" eventType="touchUpInside" id="LtR-cF-hex"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
@@ -218,7 +221,7 @@
                         <outlet property="matomeTextView" destination="3gj-Dt-Bve" id="Ue6-5j-q6r"/>
                         <outlet property="myScoreTextField" destination="i39-ld-Wyn" id="Z4K-Bg-IQZ"/>
                         <outlet property="opponentScoreTextField" destination="u5l-uM-MaY" id="q7N-1o-FuB"/>
-                        <outlet property="registerButton" destination="kJn-No-Q5j" id="Ulg-uT-AoA"/>
+                        <outlet property="registerButton" destination="kJn-No-Q5j" id="qlk-os-N2W"/>
                         <outlet property="secondHalfTextView" destination="AM9-Fv-Aa6" id="gZu-qI-yfh"/>
                         <outlet property="teamTextField" destination="HMf-mO-THt" id="D0g-D1-TOC"/>
                     </connections>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -181,11 +181,14 @@
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kJn-No-Q5j">
                                 <rect key="frame" x="139.66666666666666" y="718" width="96" height="36"/>
+                                <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="kJn-No-Q5j" secondAttribute="height" multiplier="8:3" id="KCl-4b-Hv7"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
-                                <state key="normal" title="Button"/>
+                                <state key="normal" title="登録">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="SjI-ID-hWl"/>
@@ -215,6 +218,7 @@
                         <outlet property="matomeTextView" destination="3gj-Dt-Bve" id="Ue6-5j-q6r"/>
                         <outlet property="myScoreTextField" destination="i39-ld-Wyn" id="Z4K-Bg-IQZ"/>
                         <outlet property="opponentScoreTextField" destination="u5l-uM-MaY" id="q7N-1o-FuB"/>
+                        <outlet property="registerButton" destination="kJn-No-Q5j" id="Ulg-uT-AoA"/>
                         <outlet property="secondHalfTextView" destination="AM9-Fv-Aa6" id="gZu-qI-yfh"/>
                         <outlet property="teamTextField" destination="HMf-mO-THt" id="D0g-D1-TOC"/>
                     </connections>

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -34,9 +34,13 @@ class GameRegisterViewController: UIViewController,UITextFieldDelegate,UINavigat
         myScoreTextField.delegate = self
         opponentScoreTextField.delegate = self
         
-        setupKeyboard()
-        setupTextView()
+        setupFirst()
+    }
+    
+    func setupFirst() {
         setupRegisterButton()
+        setupTextView()
+        setupKeyboard()
     }
     
     func setupRegisterButton() {

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -16,6 +16,7 @@ class GameRegisterViewController: UIViewController,UITextFieldDelegate,UINavigat
     @IBOutlet weak var firstHalfTextView: UITextView!
     @IBOutlet weak var secondHalfTextView: UITextView!
     @IBOutlet weak var matomeTextView: UITextView!
+    @IBOutlet weak var registerButton: UIButton!
     
     @IBAction func backToGameManagement(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
@@ -31,6 +32,11 @@ class GameRegisterViewController: UIViewController,UITextFieldDelegate,UINavigat
         
         setupKeyboard()
         setupTextView()
+        setupRegisterButton()
+    }
+    
+    func setupRegisterButton() {
+        registerButton.layer.cornerRadius = 15.0
     }
     
     func setupTextView() {

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -21,6 +21,9 @@ class GameRegisterViewController: UIViewController,UITextFieldDelegate,UINavigat
     @IBAction func backToGameManagement(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
     }
+    @IBAction func registerButtonToBack(_ sender: UIButton) {
+        self.dismiss(animated: true, completion: nil)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -18,10 +18,11 @@ class GameRegisterViewController: UIViewController,UITextFieldDelegate,UINavigat
     @IBOutlet weak var matomeTextView: UITextView!
     @IBOutlet weak var registerButton: UIButton!
     
-    @IBAction func backToGameManagement(_ sender: UIBarButtonItem) {
+    @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
     }
-    @IBAction func registerButtonToBack(_ sender: UIButton) {
+    
+    @IBAction func didTapRegisterButton(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
     }
     


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-Register-Button https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合登録画面 登録ボタン実装

**概要**
登録ボタンを実装。
ボタンタップで試合管理画面に画面遷移。

**レビューで見て欲しいポイント**
オートレイアウトの付け方。

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741

**補足**
Storyboard ViewをiPhone12miniに変更　に関しては、ただ自分が変更したいと思って変更しました。
ここの作業ブランチとは何も関係ありません、すいません。