### PR TITLE
試合管理画面Cellタップで試合登録画面に遷移　実装

### DIFF
--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -42,6 +42,7 @@
                     <connections>
                         <outlet property="gameAddButton" destination="tMa-K9-bVj" id="C7s-Um-wN3"/>
                         <outlet property="gameManagementTableView" destination="Dte-cP-JJe" id="KlS-Te-5ii"/>
+                        <segue destination="rP5-fx-GU0" kind="presentation" identifier="gameRegister" id="scN-CC-TLH"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -250,6 +251,9 @@
             <point key="canvasLocation" x="140.57971014492756" y="110.49107142857143"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="scN-CC-TLH"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="chevron.backward" catalog="system" width="96" height="128"/>
         <systemColor name="labelColor">

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -49,4 +49,9 @@ extension GameManagementViewController: UITableViewDelegate,UITableViewDataSourc
         return cell
     }
     
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        performSegue(withIdentifier: "gameRegister", sender: nil)
+    }
+    
 }


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-TableViewCell-ScreenTransition https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合管理画面→試合登録画面 Cellタップで画面遷移

**概要**
試合管理画面のCellをタップすると試合登録画面に遷移する実装をしました。
Segueでの画面遷移を実装しています。

**レビューで見て欲しいポイント**
Segueでの画面遷移の実装方法に問題はないか。
identifierの命名に問題はないか。
もしくは他の方法を使った遷移方法がいいのかレビュー頂きたいです。

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741