### PR TITLE
試合編集画面　実装

### DIFF
--- a/SoccerNoteApp.xcodeproj/project.pbxproj
+++ b/SoccerNoteApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,6 +11,7 @@
 		5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */; };
 		5D14B37625565ADB002CA3D4 /* GameManagementTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */; };
 		5D18C04525691DDA00FE56AF /* GameManagementTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D18C04425691DDA00FE56AF /* GameManagementTableViewCell.xib */; };
+		5DA8B4032579590A00E02818 /* GameEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA8B4022579590A00E02818 /* GameEditViewController.swift */; };
 		5DAC50D3253DF01400F788BA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D2253DF01400F788BA /* AppDelegate.swift */; };
 		5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D4253DF01400F788BA /* SceneDelegate.swift */; };
 		5DAC50D7253DF01400F788BA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC50D6253DF01400F788BA /* ViewController.swift */; };
@@ -48,6 +49,7 @@
 		5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementViewController.swift; sourceTree = "<group>"; };
 		5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementTableViewCell.swift; sourceTree = "<group>"; };
 		5D18C04425691DDA00FE56AF /* GameManagementTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GameManagementTableViewCell.xib; sourceTree = "<group>"; };
+		5DA8B4022579590A00E02818 /* GameEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEditViewController.swift; sourceTree = "<group>"; };
 		5DAC50CF253DF01400F788BA /* SoccerNoteApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SoccerNoteApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DAC50D2253DF01400F788BA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5DAC50D4253DF01400F788BA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 				5D18C04425691DDA00FE56AF /* GameManagementTableViewCell.xib */,
 				5D14B370255659FA002CA3D4 /* GameManagementViewController.swift */,
 				5DEB73B5255FA1A900FD06E3 /* GameRegisterViewController.swift */,
+				5DA8B4022579590A00E02818 /* GameEditViewController.swift */,
 				5DAC50D8253DF01400F788BA /* Main.storyboard */,
 				5DAC50DB253DF01600F788BA /* Assets.xcassets */,
 				5DAC50DD253DF01600F788BA /* LaunchScreen.storyboard */,
@@ -177,7 +180,6 @@
 				115F135CA71328672A592ED8 /* Pods-SoccerNoteAppTests.debug.xcconfig */,
 				BA673359A16D73500144469D /* Pods-SoccerNoteAppTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -426,6 +428,7 @@
 				5DAC50D5253DF01400F788BA /* SceneDelegate.swift in Sources */,
 				5DEB73B6255FA1A900FD06E3 /* GameRegisterViewController.swift in Sources */,
 				5D14B371255659FA002CA3D4 /* GameManagementViewController.swift in Sources */,
+				5DA8B4032579590A00E02818 /* GameEditViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -303,10 +303,10 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Stack View">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Edit Stack View">
                                 <rect key="frame" x="16" y="229" width="343" height="465"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Stack View">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Edit Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="148.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-xk-bQn">
@@ -324,7 +324,7 @@
                                             </textView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Stack View">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Edit Stack View">
                                         <rect key="frame" x="0.0" y="158.33333333333331" width="343" height="148.33333333333331"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62z-tK-ZeX">
@@ -342,7 +342,7 @@
                                             </textView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Stack View">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Edit Stack View">
                                         <rect key="frame" x="0.0" y="316.66666666666663" width="343" height="148.33333333333337"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0I-rJ-K6Y">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -243,7 +243,7 @@
                                 <rect key="frame" x="0.0" y="44" width="375" height="54"/>
                                 <color key="barTintColor" red="0.1469349751" green="0.34631367410000002" blue="0.49445108259999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <items>
-                                    <navigationItem title="試合" id="SPV-5F-0AA">
+                                    <navigationItem title="編集" id="SPV-5F-0AA">
                                         <barButtonItem key="leftBarButtonItem" image="chevron.backward" catalog="system" style="plain" id="vei-Hs-DJj">
                                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <connections>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -303,17 +303,79 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Stack View">
+                                <rect key="frame" x="16" y="226" width="343" height="465"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="148.33333333333334"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-xk-bQn">
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rwk-OM-phs">
+                                                <rect key="frame" x="0.0" y="20.333333333333343" width="343" height="128"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Stack View">
+                                        <rect key="frame" x="0.0" y="158.33333333333331" width="343" height="148.33333333333331"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62z-tK-ZeX">
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="5BQ-VF-aht">
+                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="128"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Stack View">
+                                        <rect key="frame" x="0.0" y="316.66666666666663" width="343" height="148.33333333333337"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0I-rJ-K6Y">
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="8Pu-g6-wvP">
+                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="128"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6pS-Ur-o3u"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" id="0X6-cU-OFG"/>
+                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="centerX" secondItem="BSq-yI-X1g" secondAttribute="centerX" id="6bI-10-2mt"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="centerX" secondItem="Z06-EE-D7X" secondAttribute="centerX" id="Gyk-q6-ada"/>
                             <constraint firstItem="BSq-yI-X1g" firstAttribute="top" secondItem="2ie-Qz-tbo" secondAttribute="bottom" constant="8" id="JaH-V1-nqA"/>
                             <constraint firstItem="BSq-yI-X1g" firstAttribute="centerX" secondItem="2ie-Qz-tbo" secondAttribute="centerX" id="KAw-Fn-Ch6"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" constant="8" id="Khf-9r-M9s"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" constant="16" id="OwP-X8-qgH"/>
+                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="top" secondItem="BSq-yI-X1g" secondAttribute="bottom" constant="8" id="cbe-nB-ag9"/>
                             <constraint firstItem="BSq-yI-X1g" firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="width" id="dBo-tg-e2d"/>
+                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="width" secondItem="BSq-yI-X1g" secondAttribute="width" id="giv-zX-N7C"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" constant="8" id="mB8-7N-rm1"/>
                             <constraint firstItem="6pS-Ur-o3u" firstAttribute="trailing" secondItem="2ie-Qz-tbo" secondAttribute="trailing" constant="16" id="ozm-Bf-y0K"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="top" secondItem="6pS-Ur-o3u" secondAttribute="top" id="sNG-g7-9yZ"/>
@@ -321,9 +383,12 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="firstHalfEditTextView" destination="j6P-b8-UHv" id="ugo-8K-CVB"/>
                         <outlet property="gameEditNavigationBar" destination="Z06-EE-D7X" id="ngC-Vf-wch"/>
+                        <outlet property="matomeEditTextView" destination="8Pu-g6-wvP" id="UA2-Ff-w8x"/>
                         <outlet property="myScoreEditTextField" destination="mLL-cd-pzF" id="2ai-V4-czm"/>
                         <outlet property="opponentScoreTextField" destination="9Vv-ke-i6a" id="dzv-dF-1h7"/>
+                        <outlet property="secondHalfEditTextView" destination="5BQ-VF-aht" id="bYj-7H-jCU"/>
                         <outlet property="teamEditTextField" destination="LqK-vz-phX" id="5mL-7q-g6Y"/>
                     </connections>
                 </viewController>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -401,12 +401,12 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="editButton" destination="7e9-3y-h75" id="UcI-kX-Ekd"/>
                         <outlet property="firstHalfEditTextView" destination="rwk-OM-phs" id="cBg-Mm-nxB"/>
                         <outlet property="gameEditNavigationBar" destination="Z06-EE-D7X" id="ngC-Vf-wch"/>
                         <outlet property="matomeEditTextView" destination="8Pu-g6-wvP" id="UA2-Ff-w8x"/>
                         <outlet property="myScoreEditTextField" destination="LqK-vz-phX" id="lfv-CV-c9T"/>
                         <outlet property="opponentScoreEditTextField" destination="9Vv-ke-i6a" id="4Eo-IJ-2W3"/>
-                        <outlet property="registerEditButton" destination="7e9-3y-h75" id="wMe-Ni-g1d"/>
                         <outlet property="secondHalfEditTextView" destination="5BQ-VF-aht" id="bYj-7H-jCU"/>
                         <outlet property="teamEditTextField" destination="LqK-vz-phX" id="5mL-7q-g6Y"/>
                     </connections>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -238,13 +238,37 @@
                     <view key="view" contentMode="scaleToFill" id="mLL-cd-pzF">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z06-EE-D7X">
+                                <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                <color key="barTintColor" red="0.1469349751" green="0.34631367410000002" blue="0.49445108259999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <items>
+                                    <navigationItem title="試合" id="SPV-5F-0AA">
+                                        <barButtonItem key="leftBarButtonItem" image="chevron.backward" catalog="system" style="plain" id="vei-Hs-DJj">
+                                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <connections>
+                                                <action selector="didTapBackButton:" destination="dYk-Ue-BcU" id="pN6-hi-oI6"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6pS-Ur-o3u"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Z06-EE-D7X" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" id="0X6-cU-OFG"/>
+                            <constraint firstItem="Z06-EE-D7X" firstAttribute="top" secondItem="6pS-Ur-o3u" secondAttribute="top" id="sNG-g7-9yZ"/>
+                            <constraint firstItem="Z06-EE-D7X" firstAttribute="trailing" secondItem="6pS-Ur-o3u" secondAttribute="trailing" id="tKI-PC-uas"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="gameEditNavigationBar" destination="Z06-EE-D7X" id="ngC-Vf-wch"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jCo-98-oLi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1911" y="853"/>
+            <point key="canvasLocation" x="1911" y="852"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="pxE-C4-7s9">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -254,20 +254,66 @@
                                 </items>
                             </navigationBar>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
-                                <rect key="frame" x="16" y="96" width="343" height="34"/>
+                                <rect key="frame" x="16" y="96" width="343" height="34.333333333333343"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="U1n-rU-sSs"/>
                                 </constraints>
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="BSq-yI-X1g" userLabel="Game Data Edit Stack View">
+                                <rect key="frame" x="16" y="138.33333333333334" width="343" height="72.666666666666657"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MM1-b1-LUu" userLabel="Team Edit Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ygs-v4-BCY">
+                                                <rect key="frame" x="0.0" y="0.0" width="32.333333333333336" height="31.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ke2-7z-oI5">
+                                                <rect key="frame" x="48.333333333333343" y="0.0" width="294.66666666666663" height="31.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="ycG-9u-4q1" userLabel="Score Edit Stack View">
+                                        <rect key="frame" x="0.0" y="41.333333333333314" width="343" height="31.333333333333329"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LqK-vz-phX">
+                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="31.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJp-JM-Oor">
+                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9Vv-ke-i6a">
+                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6pS-Ur-o3u"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" id="0X6-cU-OFG"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="centerX" secondItem="Z06-EE-D7X" secondAttribute="centerX" id="Gyk-q6-ada"/>
+                            <constraint firstItem="BSq-yI-X1g" firstAttribute="top" secondItem="2ie-Qz-tbo" secondAttribute="bottom" constant="8" id="JaH-V1-nqA"/>
+                            <constraint firstItem="BSq-yI-X1g" firstAttribute="centerX" secondItem="2ie-Qz-tbo" secondAttribute="centerX" id="KAw-Fn-Ch6"/>
+                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" constant="8" id="Khf-9r-M9s"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" constant="16" id="OwP-X8-qgH"/>
+                            <constraint firstItem="BSq-yI-X1g" firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="width" id="dBo-tg-e2d"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" constant="8" id="mB8-7N-rm1"/>
                             <constraint firstItem="6pS-Ur-o3u" firstAttribute="trailing" secondItem="2ie-Qz-tbo" secondAttribute="trailing" constant="16" id="ozm-Bf-y0K"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="top" secondItem="6pS-Ur-o3u" secondAttribute="top" id="sNG-g7-9yZ"/>
@@ -276,6 +322,9 @@
                     </view>
                     <connections>
                         <outlet property="gameEditNavigationBar" destination="Z06-EE-D7X" id="ngC-Vf-wch"/>
+                        <outlet property="myScoreEditTextField" destination="mLL-cd-pzF" id="2ai-V4-czm"/>
+                        <outlet property="opponentScoreTextField" destination="9Vv-ke-i6a" id="dzv-dF-1h7"/>
+                        <outlet property="teamEditTextField" destination="LqK-vz-phX" id="5mL-7q-g6Y"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jCo-98-oLi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -240,7 +240,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z06-EE-D7X">
-                                <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="54"/>
                                 <color key="barTintColor" red="0.1469349751" green="0.34631367410000002" blue="0.49445108259999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <items>
                                     <navigationItem title="試合" id="SPV-5F-0AA">
@@ -254,7 +254,7 @@
                                 </items>
                             </navigationBar>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
-                                <rect key="frame" x="16" y="96" width="343" height="34.333333333333343"/>
+                                <rect key="frame" x="16" y="106" width="343" height="34.333333333333343"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="U1n-rU-sSs"/>
@@ -262,7 +262,7 @@
                                 <locale key="locale" localeIdentifier="ja_JP"/>
                             </datePicker>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="BSq-yI-X1g" userLabel="Game Data Edit Stack View">
-                                <rect key="frame" x="16" y="138.33333333333334" width="343" height="72.666666666666657"/>
+                                <rect key="frame" x="16" y="148.33333333333334" width="343" height="72.666666666666657"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MM1-b1-LUu" userLabel="Team Edit Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
@@ -303,10 +303,10 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Stack View">
-                                <rect key="frame" x="16" y="226" width="343" height="465"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Stack View">
+                                <rect key="frame" x="16" y="229" width="343" height="465"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Stack View">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="148.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-xk-bQn">
@@ -315,7 +315,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rwk-OM-phs">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rwk-OM-phs">
                                                 <rect key="frame" x="0.0" y="20.333333333333343" width="343" height="128"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -324,7 +324,7 @@
                                             </textView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Stack View">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Stack View">
                                         <rect key="frame" x="0.0" y="158.33333333333331" width="343" height="148.33333333333331"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62z-tK-ZeX">
@@ -333,7 +333,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="5BQ-VF-aht">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="5BQ-VF-aht">
                                                 <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="128"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -342,7 +342,7 @@
                                             </textView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Stack View">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Stack View">
                                         <rect key="frame" x="0.0" y="316.66666666666663" width="343" height="148.33333333333337"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0I-rJ-K6Y">
@@ -351,7 +351,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="8Pu-g6-wvP">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="8Pu-g6-wvP">
                                                 <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="128"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -362,6 +362,21 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7e9-3y-h75">
+                                <rect key="frame" x="139.66666666666666" y="718" width="96" height="36"/>
+                                <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="7e9-3y-h75" secondAttribute="height" multiplier="8:3" id="Txy-bU-cAy"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
+                                <state key="normal" title="登録">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="didTapRegisterButton:" destination="rP5-fx-GU0" eventType="touchUpInside" id="hcc-uo-0NG"/>
+                                    <action selector="didTapRegisterEditButton:" destination="dYk-Ue-BcU" eventType="touchUpInside" id="9Cs-vC-qSU"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6pS-Ur-o3u"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -376,18 +391,22 @@
                             <constraint firstItem="ZC7-ZI-fiY" firstAttribute="top" secondItem="BSq-yI-X1g" secondAttribute="bottom" constant="8" id="cbe-nB-ag9"/>
                             <constraint firstItem="BSq-yI-X1g" firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="width" id="dBo-tg-e2d"/>
                             <constraint firstItem="ZC7-ZI-fiY" firstAttribute="width" secondItem="BSq-yI-X1g" secondAttribute="width" id="giv-zX-N7C"/>
+                            <constraint firstItem="6pS-Ur-o3u" firstAttribute="bottom" secondItem="7e9-3y-h75" secondAttribute="bottom" constant="24" id="kaO-Ai-EvH"/>
                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" constant="8" id="mB8-7N-rm1"/>
+                            <constraint firstItem="7e9-3y-h75" firstAttribute="centerX" secondItem="ZC7-ZI-fiY" secondAttribute="centerX" id="nud-uL-a0d"/>
+                            <constraint firstItem="7e9-3y-h75" firstAttribute="top" secondItem="ZC7-ZI-fiY" secondAttribute="bottom" constant="24" id="o0b-P5-8us"/>
                             <constraint firstItem="6pS-Ur-o3u" firstAttribute="trailing" secondItem="2ie-Qz-tbo" secondAttribute="trailing" constant="16" id="ozm-Bf-y0K"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="top" secondItem="6pS-Ur-o3u" secondAttribute="top" id="sNG-g7-9yZ"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="trailing" secondItem="6pS-Ur-o3u" secondAttribute="trailing" id="tKI-PC-uas"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="firstHalfEditTextView" destination="j6P-b8-UHv" id="ugo-8K-CVB"/>
+                        <outlet property="firstHalfEditTextView" destination="rwk-OM-phs" id="cBg-Mm-nxB"/>
                         <outlet property="gameEditNavigationBar" destination="Z06-EE-D7X" id="ngC-Vf-wch"/>
                         <outlet property="matomeEditTextView" destination="8Pu-g6-wvP" id="UA2-Ff-w8x"/>
                         <outlet property="myScoreEditTextField" destination="mLL-cd-pzF" id="2ai-V4-czm"/>
                         <outlet property="opponentScoreTextField" destination="9Vv-ke-i6a" id="dzv-dF-1h7"/>
+                        <outlet property="registerEditButton" destination="7e9-3y-h75" id="wMe-Ni-g1d"/>
                         <outlet property="secondHalfEditTextView" destination="5BQ-VF-aht" id="bYj-7H-jCU"/>
                         <outlet property="teamEditTextField" destination="LqK-vz-phX" id="5mL-7q-g6Y"/>
                     </connections>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -42,6 +42,7 @@
                     <connections>
                         <outlet property="gameAddButton" destination="tMa-K9-bVj" id="C7s-Um-wN3"/>
                         <outlet property="gameManagementTableView" destination="Dte-cP-JJe" id="KlS-Te-5ii"/>
+                        <segue destination="dYk-Ue-BcU" kind="presentation" identifier="gameEdit" id="Bso-bp-HOe"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -233,7 +234,7 @@
         <!--Game Edit View Controller-->
         <scene sceneID="42S-Vn-j2h">
             <objects>
-                <viewController id="dYk-Ue-BcU" customClass="GameEditViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="dYk-Ue-BcU" customClass="GameEditViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mLL-cd-pzF">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -243,7 +244,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jCo-98-oLi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1911" y="797"/>
+            <point key="canvasLocation" x="1911" y="853"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="pxE-C4-7s9">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -230,6 +230,21 @@
             </objects>
             <point key="canvasLocation" x="1911.2" y="109.35960591133005"/>
         </scene>
+        <!--Game Edit View Controller-->
+        <scene sceneID="42S-Vn-j2h">
+            <objects>
+                <viewController id="dYk-Ue-BcU" customClass="GameEditViewController" customModule="SoccerNoteApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="mLL-cd-pzF">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6pS-Ur-o3u"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jCo-98-oLi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1911" y="797"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="pxE-C4-7s9">
             <objects>

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -253,11 +253,23 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
+                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
+                                <rect key="frame" x="16" y="96" width="343" height="34"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="U1n-rU-sSs"/>
+                                </constraints>
+                                <locale key="locale" localeIdentifier="ja_JP"/>
+                            </datePicker>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6pS-Ur-o3u"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" id="0X6-cU-OFG"/>
+                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="centerX" secondItem="Z06-EE-D7X" secondAttribute="centerX" id="Gyk-q6-ada"/>
+                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" constant="16" id="OwP-X8-qgH"/>
+                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" constant="8" id="mB8-7N-rm1"/>
+                            <constraint firstItem="6pS-Ur-o3u" firstAttribute="trailing" secondItem="2ie-Qz-tbo" secondAttribute="trailing" constant="16" id="ozm-Bf-y0K"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="top" secondItem="6pS-Ur-o3u" secondAttribute="top" id="sNG-g7-9yZ"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="trailing" secondItem="6pS-Ur-o3u" secondAttribute="trailing" id="tKI-PC-uas"/>
                         </constraints>
@@ -268,7 +280,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jCo-98-oLi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1911" y="852"/>
+            <point key="canvasLocation" x="1909.5999999999999" y="851.97044334975374"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="pxE-C4-7s9">

--- a/SoccerNoteApp/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/Base.lproj/Main.storyboard
@@ -404,8 +404,8 @@
                         <outlet property="firstHalfEditTextView" destination="rwk-OM-phs" id="cBg-Mm-nxB"/>
                         <outlet property="gameEditNavigationBar" destination="Z06-EE-D7X" id="ngC-Vf-wch"/>
                         <outlet property="matomeEditTextView" destination="8Pu-g6-wvP" id="UA2-Ff-w8x"/>
-                        <outlet property="myScoreEditTextField" destination="mLL-cd-pzF" id="2ai-V4-czm"/>
-                        <outlet property="opponentScoreTextField" destination="9Vv-ke-i6a" id="dzv-dF-1h7"/>
+                        <outlet property="myScoreEditTextField" destination="LqK-vz-phX" id="lfv-CV-c9T"/>
+                        <outlet property="opponentScoreEditTextField" destination="9Vv-ke-i6a" id="4Eo-IJ-2W3"/>
                         <outlet property="registerEditButton" destination="7e9-3y-h75" id="wMe-Ni-g1d"/>
                         <outlet property="secondHalfEditTextView" destination="5BQ-VF-aht" id="bYj-7H-jCU"/>
                         <outlet property="teamEditTextField" destination="LqK-vz-phX" id="5mL-7q-g6Y"/>

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class GameEditViewController: UIViewController,UITextFieldDelegate,UINavigationBarDelegate {
+class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigationBarDelegate {
     
     @IBOutlet weak var gameEditNavigationBar: UINavigationBar!
     @IBOutlet weak var teamEditTextField: UITextField!
@@ -16,14 +16,14 @@ class GameEditViewController: UIViewController,UITextFieldDelegate,UINavigationB
     @IBOutlet weak var firstHalfEditTextView: UITextView!
     @IBOutlet weak var secondHalfEditTextView: UITextView!
     @IBOutlet weak var matomeEditTextView: UITextView!
-    @IBOutlet weak var registerEditButton: UIButton!
+    @IBOutlet weak var editButton: UIButton!
     
     @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
     }
     
-    @IBAction func didTapRegisterEditButton(_ sender: UIButton) {
-        self.dismiss(animated: true, completion: nil)
+    @IBAction func didTapEditButton(_ sender: UIButton) {
+        dismiss(animated: true, completion: nil)
     }
     
     override func viewDidLoad() {
@@ -39,17 +39,17 @@ class GameEditViewController: UIViewController,UITextFieldDelegate,UINavigationB
     
     private func setupFirst() {
         setupKeyboard()
-        setupRegisterEditButton()
+        setupEditButton()
         setupEditTextView()
     }
     
     private func setupKeyboard() {
-        self.myScoreEditTextField.keyboardType = UIKeyboardType.numberPad
-        self.opponentScoreEditTextField.keyboardType = UIKeyboardType.numberPad
+        myScoreEditTextField.keyboardType = UIKeyboardType.numberPad
+        opponentScoreEditTextField.keyboardType = UIKeyboardType.numberPad
     }
     
-    private func setupRegisterEditButton() {
-        registerEditButton.layer.cornerRadius = 15.0
+    private func setupEditButton() {
+        editButton.layer.cornerRadius = 15.0
     }
     
     private func setupEditTextView() {
@@ -69,5 +69,4 @@ class GameEditViewController: UIViewController,UITextFieldDelegate,UINavigationB
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
     }
-
 }

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -11,7 +11,7 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
     
     @IBOutlet weak var gameEditNavigationBar: UINavigationBar!
     @IBOutlet weak var teamEditTextField: UITextField!
-    @IBOutlet var myScoreEditTextField: UIView!
+    @IBOutlet weak var myScoreEditTextField: UITextField!
     @IBOutlet weak var opponentScoreEditTextField: UITextField!
     @IBOutlet weak var firstHalfEditTextView: UITextView!
     @IBOutlet weak var secondHalfEditTextView: UITextView!

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 class GameEditViewController: UIViewController,UINavigationBarDelegate {
     
     @IBOutlet weak var gameEditNavigationBar: UINavigationBar!
+    @IBOutlet weak var teamEditTextField: UITextField!
+    @IBOutlet var myScoreEditTextField: UIView!
+    @IBOutlet weak var opponentScoreTextField: UITextField!
     
     @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -12,18 +12,6 @@ class GameEditViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -1,0 +1,29 @@
+//
+//  GameEditViewController.swift
+//  SoccerNoteApp
+//
+//  Created by hideto c. on 2020/12/04.
+//
+
+import UIKit
+
+class GameEditViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -13,11 +13,16 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
     @IBOutlet weak var teamEditTextField: UITextField!
     @IBOutlet var myScoreEditTextField: UIView!
     @IBOutlet weak var opponentScoreTextField: UITextField!
-    @IBOutlet weak var firstHalfEditTextView: UIStackView!
+    @IBOutlet weak var firstHalfEditTextView: UITextView!
     @IBOutlet weak var secondHalfEditTextView: UITextView!
     @IBOutlet weak var matomeEditTextView: UITextView!
+    @IBOutlet weak var registerEditButton: UIButton!
     
     @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func didTapRegisterEditButton(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
     }
     
@@ -30,10 +35,15 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
     }
     
     private func setupFirst() {
-        setupTextView()
+        setupRegisterEditButton()
+        setupEditTextView()
     }
     
-    private func setupTextView() {
+    private func setupRegisterEditButton() {
+        registerEditButton.layer.cornerRadius = 15.0
+    }
+    
+    private func setupEditTextView() {
             firstHalfEditTextView.layer.borderWidth = 1.0
             secondHalfEditTextView.layer.borderWidth = 1.0
             matomeEditTextView.layer.borderWidth = 1.0

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -9,20 +9,20 @@ import UIKit
 
 class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigationBarDelegate {
     
-    @IBOutlet weak var gameEditNavigationBar: UINavigationBar!
-    @IBOutlet weak var teamEditTextField: UITextField!
-    @IBOutlet weak var myScoreEditTextField: UITextField!
-    @IBOutlet weak var opponentScoreEditTextField: UITextField!
-    @IBOutlet weak var firstHalfEditTextView: UITextView!
-    @IBOutlet weak var secondHalfEditTextView: UITextView!
-    @IBOutlet weak var matomeEditTextView: UITextView!
-    @IBOutlet weak var editButton: UIButton!
+    @IBOutlet weak private var gameEditNavigationBar: UINavigationBar!
+    @IBOutlet weak private var teamEditTextField: UITextField!
+    @IBOutlet weak private var myScoreEditTextField: UITextField!
+    @IBOutlet weak private var opponentScoreEditTextField: UITextField!
+    @IBOutlet weak private var firstHalfEditTextView: UITextView!
+    @IBOutlet weak private var secondHalfEditTextView: UITextView!
+    @IBOutlet weak private var matomeEditTextView: UITextView!
+    @IBOutlet weak private var editButton: UIButton!
     
-    @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
+    @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
     
-    @IBAction func didTapEditButton(_ sender: UIButton) {
+    @IBAction private func didTapEditButton(_ sender: UIButton) {
         dismiss(animated: true, completion: nil)
     }
     

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class GameEditViewController: UIViewController,UINavigationBarDelegate {
+class GameEditViewController: UIViewController,UITextFieldDelegate,UINavigationBarDelegate {
     
     @IBOutlet weak var gameEditNavigationBar: UINavigationBar!
     @IBOutlet weak var teamEditTextField: UITextField!
@@ -30,13 +30,22 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
         super.viewDidLoad()
 
         gameEditNavigationBar.delegate = self
+        teamEditTextField.delegate = self
+        myScoreEditTextField.delegate = self
+        opponentScoreEditTextField.delegate = self
         
         setupFirst()
     }
     
     private func setupFirst() {
+        setupKeyboard()
         setupRegisterEditButton()
         setupEditTextView()
+    }
+    
+    private func setupKeyboard() {
+        self.myScoreEditTextField.keyboardType = UIKeyboardType.numberPad
+        self.opponentScoreEditTextField.keyboardType = UIKeyboardType.numberPad
     }
     
     private func setupRegisterEditButton() {
@@ -51,6 +60,14 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
     
     func position(for bar: UIBarPositioning) -> UIBarPosition {
         return .topAttached
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
     }
 
 }

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -12,7 +12,7 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
     @IBOutlet weak var gameEditNavigationBar: UINavigationBar!
     @IBOutlet weak var teamEditTextField: UITextField!
     @IBOutlet var myScoreEditTextField: UIView!
-    @IBOutlet weak var opponentScoreTextField: UITextField!
+    @IBOutlet weak var opponentScoreEditTextField: UITextField!
     @IBOutlet weak var firstHalfEditTextView: UITextView!
     @IBOutlet weak var secondHalfEditTextView: UITextView!
     @IBOutlet weak var matomeEditTextView: UITextView!

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -13,6 +13,9 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
     @IBOutlet weak var teamEditTextField: UITextField!
     @IBOutlet var myScoreEditTextField: UIView!
     @IBOutlet weak var opponentScoreTextField: UITextField!
+    @IBOutlet weak var firstHalfEditTextView: UIStackView!
+    @IBOutlet weak var secondHalfEditTextView: UITextView!
+    @IBOutlet weak var matomeEditTextView: UITextView!
     
     @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
@@ -22,6 +25,18 @@ class GameEditViewController: UIViewController,UINavigationBarDelegate {
         super.viewDidLoad()
 
         gameEditNavigationBar.delegate = self
+        
+        setupFirst()
+    }
+    
+    private func setupFirst() {
+        setupTextView()
+    }
+    
+    private func setupTextView() {
+            firstHalfEditTextView.layer.borderWidth = 1.0
+            secondHalfEditTextView.layer.borderWidth = 1.0
+            matomeEditTextView.layer.borderWidth = 1.0
     }
     
     func position(for bar: UIBarPositioning) -> UIBarPosition {

--- a/SoccerNoteApp/GameEditViewController.swift
+++ b/SoccerNoteApp/GameEditViewController.swift
@@ -7,11 +7,22 @@
 
 import UIKit
 
-class GameEditViewController: UIViewController {
-
+class GameEditViewController: UIViewController,UINavigationBarDelegate {
+    
+    @IBOutlet weak var gameEditNavigationBar: UINavigationBar!
+    
+    @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        gameEditNavigationBar.delegate = self
+    }
+    
+    func position(for bar: UIBarPositioning) -> UIBarPosition {
+        return .topAttached
     }
 
 }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -11,8 +11,8 @@ class GameManagementViewController: UIViewController {
     
     private let cellId = "cellId"
     
-    @IBOutlet weak var gameManagementTableView: UITableView!
-    @IBOutlet weak var gameAddButton: UIBarButtonItem!
+    @IBOutlet weak private var gameManagementTableView: UITableView!
+    @IBOutlet weak private var gameAddButton: UIBarButtonItem!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -49,4 +49,9 @@ extension GameManagementViewController: UITableViewDelegate,UITableViewDataSourc
         return cell
     }
     
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        performSegue(withIdentifier: "gameEdit", sender: nil)
+    }
+    
 }

--- a/SoccerNoteApp/GameManagementViewController.swift
+++ b/SoccerNoteApp/GameManagementViewController.swift
@@ -53,5 +53,4 @@ extension GameManagementViewController: UITableViewDelegate,UITableViewDataSourc
         tableView.deselectRow(at: indexPath, animated: true)
         performSegue(withIdentifier: "gameEdit", sender: nil)
     }
-    
 }

--- a/SoccerNoteApp/GameRegisterViewController.swift
+++ b/SoccerNoteApp/GameRegisterViewController.swift
@@ -9,20 +9,20 @@ import UIKit
 
 class GameRegisterViewController: UIViewController,UITextFieldDelegate,UINavigationBarDelegate {
     
-    @IBOutlet weak var gameNavigationBar: UINavigationBar!
-    @IBOutlet weak var teamTextField: UITextField!
-    @IBOutlet weak var myScoreTextField: UITextField!
-    @IBOutlet weak var opponentScoreTextField: UITextField!
-    @IBOutlet weak var firstHalfTextView: UITextView!
-    @IBOutlet weak var secondHalfTextView: UITextView!
-    @IBOutlet weak var matomeTextView: UITextView!
-    @IBOutlet weak var registerButton: UIButton!
+    @IBOutlet weak private var gameNavigationBar: UINavigationBar!
+    @IBOutlet weak private var teamTextField: UITextField!
+    @IBOutlet weak private var myScoreTextField: UITextField!
+    @IBOutlet weak private var opponentScoreTextField: UITextField!
+    @IBOutlet weak private var firstHalfTextView: UITextView!
+    @IBOutlet weak private var secondHalfTextView: UITextView!
+    @IBOutlet weak private var matomeTextView: UITextView!
+    @IBOutlet weak private var registerButton: UIButton!
     
-    @IBAction func didTapBackButton(_ sender: UIBarButtonItem) {
+    @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
     }
     
-    @IBAction func didTapRegisterButton(_ sender: UIButton) {
+    @IBAction private func didTapRegisterButton(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
     }
     


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-UI-gameEdit https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
試合編集画面　実装

**概要**
試合編集画面を実装しました。
UIは全く試合登録画面と一緒です。

**レビューで見て欲しいポイント**
setupのメソッドの命名が試合登録画面と全く同じものがあるのですが、それは問題ないのでしょうか。
少しお話した部分なのですが、この場合extensionを使った方が良いのかレビュー頂きたいです。

**実機build/期待通りの挙動をするか**
OK

※UI変更した場合のみ記述

**11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741