### PR TITLE
編集画面 登録ボタン エラー修正

### DIFF
--- a/SoccerNoteApp/Controller/GameEditViewController.swift
+++ b/SoccerNoteApp/Controller/GameEditViewController.swift
@@ -22,7 +22,7 @@ class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigatio
         dismiss(animated: true, completion: nil)
     }
     
-    @IBAction private func didTapEditButton(_ sender: UIButton) {
+    @IBAction func didTapEditButton(_ sender: UIButton) {
         dismiss(animated: true, completion: nil)
     }
     

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -373,8 +373,8 @@
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <connections>
+                                    <action selector="didTapEditButton:" destination="dYk-Ue-BcU" eventType="touchUpInside" id="WxC-cV-9M4"/>
                                     <action selector="didTapRegisterButton:" destination="rP5-fx-GU0" eventType="touchUpInside" id="hcc-uo-0NG"/>
-                                    <action selector="didTapRegisterEditButton:" destination="dYk-Ue-BcU" eventType="touchUpInside" id="9Cs-vC-qSU"/>
                                 </connections>
                             </button>
                         </subviews>


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/modification-EditButton https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
編集画面 登録ボタン エラー修正

**概要**
編集画面の登録ボタンをタップした時にアプリが落ちてしまうエラーを修正。

**レビューで見て欲しいポイント**
storyboardとcontrollerの紐付けがちゃんとできていなかったのが原因でした。
ビルド問題なしです。
Actionのアクセス修飾子を付けなくてもいいと前に言われていたので、今回修正のついでに編集登録ボタンのActionのprivateを外しました。

**実機build/期待通りの挙動をするか**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741