### PR TITLE
登録画面 登録ボタンタップ アラート表示

### DIFF
--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -38,11 +38,15 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     }
     
     @IBAction func didTapRegisterButton(_ sender: UIButton) {
-        if teamTextField.text == "" || myScoreTextField.text == "" || opponentScoreTextField.text == "" {
+        setupAlret()
+    }
+    
+    private func setupAlret() {
+        if teamTextField.text?.isEmpty == true || myScoreTextField.text?.isEmpty == true || opponentScoreTextField.text?.isEmpty == true {
             let alert = UIAlertController(title: "登録できません", message: "チーム名、スコアを記入してください", preferredStyle: UIAlertController.Style.alert)
             alert.addAction(UIAlertAction(title: "戻る", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
-        }else{
+        } else {
             createGameData()
             self.dismiss(animated: true, completion: nil)
         }

--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -38,8 +38,14 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     }
     
     @IBAction func didTapRegisterButton(_ sender: UIButton) {
-        createGameData()
-        self.dismiss(animated: true, completion: nil)
+        if teamTextField.text == "" || myScoreTextField.text == "" || opponentScoreTextField.text == "" {
+            let alert = UIAlertController(title: "あ", message: "あいう", preferredStyle: UIAlertController.Style.alert)
+            alert.addAction(UIAlertAction(title: "戻る", style: .default, handler: nil))
+            present(alert, animated: true, completion: nil)
+        }else{
+            createGameData()
+            self.dismiss(animated: true, completion: nil)
+        }
     }
     
     func createGameData() {

--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -39,7 +39,7 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     
     @IBAction func didTapRegisterButton(_ sender: UIButton) {
         if teamTextField.text == "" || myScoreTextField.text == "" || opponentScoreTextField.text == "" {
-            let alert = UIAlertController(title: "あ", message: "あいう", preferredStyle: UIAlertController.Style.alert)
+            let alert = UIAlertController(title: "登録できません", message: "チーム名、スコアを記入してください", preferredStyle: UIAlertController.Style.alert)
             alert.addAction(UIAlertAction(title: "戻る", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
         }else{

--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -38,18 +38,18 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     }
     
     @IBAction func didTapRegisterButton(_ sender: UIButton) {
-        setupAlret()
-    }
-    
-    private func setupAlret() {
-        if teamTextField.text?.isEmpty == true || myScoreTextField.text?.isEmpty == true || opponentScoreTextField.text?.isEmpty == true {
-            let alert = UIAlertController(title: "登録できません", message: "チーム名、スコアを記入してください", preferredStyle: UIAlertController.Style.alert)
-            alert.addAction(UIAlertAction(title: "戻る", style: .default, handler: nil))
-            present(alert, animated: true, completion: nil)
+        if teamTextField.text!.isEmpty || myScoreTextField.text!.isEmpty || opponentScoreTextField.text!.isEmpty {
+            setupAlret()
         } else {
             createGameData()
             self.dismiss(animated: true, completion: nil)
         }
+    }
+    
+    private func setupAlret() {
+            let alert = UIAlertController(title: "登録できません", message: "チーム名、スコアを記入してください", preferredStyle: UIAlertController.Style.alert)
+            alert.addAction(UIAlertAction(title: "戻る", style: .default, handler: nil))
+            present(alert, animated: true, completion: nil)
     }
     
     func createGameData() {


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/add-alretDisplay https://github.com/hidec-7/SoccerNoteDev.git

**Trello**
登録時のアラート表示

**概要**
登録画面の登録ボタンをタップ時に、チーム名・スコアのどれか一つでも入力されていない場合にアラートを表示して登録できないように実装。

**レビューで見て欲しいポイント**
アラート表示の実装方法に問題はないか。
アラート表示するか否かの条件分岐のコードはメソッド化した方がいいのでしょうか？
タイトル、メッセージ等の命名に問題はないか。

**実機build/期待通りの挙動をするか**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741