### PR TITLE
試合データの一覧が重複されるエラーの修正

### DIFF
--- a/SoccerNoteApp/Controller/GameManagementViewController.swift
+++ b/SoccerNoteApp/Controller/GameManagementViewController.swift
@@ -36,8 +36,9 @@ class GameManagementViewController: UIViewController {
         let ref = Database.database().reference()
         guard let uid = Auth.auth().currentUser?.uid else { return }
         
+        gameDataArray.removeAll()
+        
         ref.child(uid).observeSingleEvent(of: .value, with: { (snapshot) in
-            
             for data in snapshot.children {
                 let snapData = data as! DataSnapshot
                 let dictionarySnapData = snapData.value as! [String: Any]


### PR DESCRIPTION
**clone コマンド**
git clone -b feature/fix-read-data https://github.com/hidec-7/SoccerNoteDev.git

**実機build/期待通りの挙動をするか**
OK

**レビュー依頼**
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741

**補足**
今回の問題は、Readのブランチで解決する問題であったと思います。
ビルド時の挙動をしっかりとチェックできていなかったのが原因なので反省したいと思います。