### PR TITLE
スワイプ削除 実装 (delete処理)

### DIFF
--- a/SoccerNoteApp.xcodeproj/project.pbxproj
+++ b/SoccerNoteApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		5D14B37625565ADB002CA3D4 /* GameManagementTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */; };
 		5D18C04525691DDA00FE56AF /* GameManagementTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D18C04425691DDA00FE56AF /* GameManagementTableViewCell.xib */; };
 		5D26BB7F258BBFA500A34757 /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D26BB7E258BBFA500A34757 /* LoginModel.swift */; };
+		5D28AE1C25D04E8800D9E3FD /* GameDataDeleteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D28AE1B25D04E8800D9E3FD /* GameDataDeleteModel.swift */; };
 		5D598F1B25B9D76B00D6D013 /* GameDataReadModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D598F1A25B9D76B00D6D013 /* GameDataReadModel.swift */; };
 		5DA8B4032579590A00E02818 /* GameEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA8B4022579590A00E02818 /* GameEditViewController.swift */; };
 		5DA8B43D2581D30500E02818 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5DA8B43C2581D30500E02818 /* GoogleService-Info.plist */; };
@@ -58,6 +59,7 @@
 		5D14B37525565ADB002CA3D4 /* GameManagementTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagementTableViewCell.swift; sourceTree = "<group>"; };
 		5D18C04425691DDA00FE56AF /* GameManagementTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GameManagementTableViewCell.xib; sourceTree = "<group>"; };
 		5D26BB7E258BBFA500A34757 /* LoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModel.swift; sourceTree = "<group>"; };
+		5D28AE1B25D04E8800D9E3FD /* GameDataDeleteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDataDeleteModel.swift; sourceTree = "<group>"; };
 		5D598F1A25B9D76B00D6D013 /* GameDataReadModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDataReadModel.swift; sourceTree = "<group>"; };
 		5DA8B4022579590A00E02818 /* GameEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEditViewController.swift; sourceTree = "<group>"; };
 		5DA8B43C2581D30500E02818 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				5D598F1A25B9D76B00D6D013 /* GameDataReadModel.swift */,
 				5DC6968725CDA5DF0004A106 /* GameDataUpdateModel.swift */,
 				5DC696A525CF00360004A106 /* DateConverterModel.swift */,
+				5D28AE1B25D04E8800D9E3FD /* GameDataDeleteModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -477,6 +480,7 @@
 				5DC6968825CDA5DF0004A106 /* GameDataUpdateModel.swift in Sources */,
 				5DC696A625CF00370004A106 /* DateConverterModel.swift in Sources */,
 				5D0D1E8925B42E6700473A08 /* GameDataModel.swift in Sources */,
+				5D28AE1C25D04E8800D9E3FD /* GameDataDeleteModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SoccerNoteApp.xcodeproj/project.pbxproj
+++ b/SoccerNoteApp.xcodeproj/project.pbxproj
@@ -153,12 +153,12 @@
 			isa = PBXGroup;
 			children = (
 				5D26BB7E258BBFA500A34757 /* LoginModel.swift */,
-				5D0D1E6925B01C1700473A08 /* GameDataCreateModel.swift */,
 				5D0D1E8825B42E6700473A08 /* GameDataModel.swift */,
+				5D0D1E6925B01C1700473A08 /* GameDataCreateModel.swift */,
 				5D598F1A25B9D76B00D6D013 /* GameDataReadModel.swift */,
 				5DC6968725CDA5DF0004A106 /* GameDataUpdateModel.swift */,
-				5DC696A525CF00360004A106 /* DateConverterModel.swift */,
 				5D28AE1B25D04E8800D9E3FD /* GameDataDeleteModel.swift */,
+				5DC696A525CF00360004A106 /* DateConverterModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";

--- a/SoccerNoteApp/Controller/GameManagementViewController.swift
+++ b/SoccerNoteApp/Controller/GameManagementViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Firebase
 
 class GameManagementViewController: UIViewController {
     
@@ -72,8 +73,17 @@ extension GameManagementViewController: UITableViewDelegate, UITableViewDataSour
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            //CRUDのDeleteを実装する際に追記
+            deleteGameData(indexPath: indexPath)
+            gameManagementTableView.deleteRows(at: [indexPath as IndexPath], with: .fade)
         }
+    }
+    
+    private func deleteGameData(indexPath: IndexPath) {
+        let ref = Database.database().reference()
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        data = GameDataModel.gameDataListArray[indexPath.row]
+        ref.child(uid).child(data?.key ?? "").removeValue()
+        GameDataModel.gameDataListArray.remove(at: indexPath.row)
     }
 }
 

--- a/SoccerNoteApp/Controller/GameManagementViewController.swift
+++ b/SoccerNoteApp/Controller/GameManagementViewController.swift
@@ -72,10 +72,19 @@ extension GameManagementViewController: UITableViewDelegate, UITableViewDataSour
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            data = GameDataModel.gameDataListArray[indexPath.row]
-            GameDataDeleteModel.deleteGameData(indexPath: indexPath, dataKey: data?.key ?? "")
-            gameManagementTableView.deleteRows(at: [indexPath as IndexPath], with: .fade)
+            setupDeleteAlert(indexPath: indexPath)
         }
+    }
+    
+    private func setupDeleteAlert(indexPath: IndexPath) {
+        let deleteAlert = UIAlertController(title: "確認", message: "この試合を削除しますか？", preferredStyle: UIAlertController.Style.alert)
+        deleteAlert.addAction(UIAlertAction(title: "キャンセル", style: .cancel, handler: nil))
+        deleteAlert.addAction(UIAlertAction(title: "削除", style: .destructive, handler: { (alertAction) in
+            self.data = GameDataModel.gameDataListArray[indexPath.row]
+            GameDataDeleteModel.deleteGameData(indexPath: indexPath, dataKey: self.data?.key ?? "")
+            self.gameManagementTableView.deleteRows(at: [indexPath as IndexPath], with: .fade)
+        }))
+        present(deleteAlert, animated: true, completion: nil)
     }
     
     func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {

--- a/SoccerNoteApp/Controller/GameManagementViewController.swift
+++ b/SoccerNoteApp/Controller/GameManagementViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Firebase
 
 class GameManagementViewController: UIViewController {
     
@@ -73,17 +72,14 @@ extension GameManagementViewController: UITableViewDelegate, UITableViewDataSour
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            deleteGameData(indexPath: indexPath)
+            data = GameDataModel.gameDataListArray[indexPath.row]
+            GameDataDeleteModel.deleteGameData(indexPath: indexPath, dataKey: data?.key ?? "")
             gameManagementTableView.deleteRows(at: [indexPath as IndexPath], with: .fade)
         }
     }
     
-    private func deleteGameData(indexPath: IndexPath) {
-        let ref = Database.database().reference()
-        guard let uid = Auth.auth().currentUser?.uid else { return }
-        data = GameDataModel.gameDataListArray[indexPath.row]
-        ref.child(uid).child(data?.key ?? "").removeValue()
-        GameDataModel.gameDataListArray.remove(at: indexPath.row)
+    func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+        return "削除"
     }
 }
 

--- a/SoccerNoteApp/Controller/GameManagementViewController.swift
+++ b/SoccerNoteApp/Controller/GameManagementViewController.swift
@@ -72,18 +72,18 @@ extension GameManagementViewController: UITableViewDelegate, UITableViewDataSour
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            setupDeleteAlert(indexPath: indexPath)
+            showAlertDeleteGameData(indexPath: indexPath)
         }
     }
     
-    private func setupDeleteAlert(indexPath: IndexPath) {
+    private func showAlertDeleteGameData(indexPath: IndexPath) {
         let deleteAlert = UIAlertController(title: "確認", message: "この試合を削除しますか？", preferredStyle: UIAlertController.Style.alert)
         deleteAlert.addAction(UIAlertAction(title: "キャンセル", style: .cancel, handler: nil))
-        deleteAlert.addAction(UIAlertAction(title: "削除", style: .destructive, handler: { (alertAction) in
+        deleteAlert.addAction(UIAlertAction(title: "削除", style: .destructive) { (_) in
             self.data = GameDataModel.gameDataListArray[indexPath.row]
             GameDataDeleteModel.deleteGameData(indexPath: indexPath, dataKey: self.data?.key ?? "")
             self.gameManagementTableView.deleteRows(at: [indexPath as IndexPath], with: .fade)
-        }))
+        })
         present(deleteAlert, animated: true, completion: nil)
     }
     

--- a/SoccerNoteApp/Controller/GameManagementViewController.swift
+++ b/SoccerNoteApp/Controller/GameManagementViewController.swift
@@ -78,12 +78,14 @@ extension GameManagementViewController: UITableViewDelegate, UITableViewDataSour
     
     private func showAlertDeleteGameData(indexPath: IndexPath) {
         let deleteAlert = UIAlertController(title: "確認", message: "この試合を削除しますか？", preferredStyle: UIAlertController.Style.alert)
-        deleteAlert.addAction(UIAlertAction(title: "キャンセル", style: .cancel, handler: nil))
-        deleteAlert.addAction(UIAlertAction(title: "削除", style: .destructive) { (_) in
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: nil)
+        let deleteAction = UIAlertAction(title: "削除", style: .destructive) { (_) in
             self.data = GameDataModel.gameDataListArray[indexPath.row]
             GameDataDeleteModel.deleteGameData(indexPath: indexPath, dataKey: self.data?.key ?? "")
             self.gameManagementTableView.deleteRows(at: [indexPath as IndexPath], with: .fade)
-        })
+        }
+        deleteAlert.addAction(cancelAction)
+        deleteAlert.addAction(deleteAction)
         present(deleteAlert, animated: true, completion: nil)
     }
     

--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -39,7 +39,7 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     
     @IBAction func didTapRegisterButton(_ sender: UIButton) {
         if teamTextField.text!.isEmpty || myScoreTextField.text!.isEmpty || opponentScoreTextField.text!.isEmpty {
-            setupAlret()
+            setupRegisterAlret()
         } else {
             GameDataCreateModel.createGameData(gameDate: gameDatePicker.date,
                                                team: teamTextField.text ?? "",
@@ -52,7 +52,7 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
         }
     }
     
-    private func setupAlret() {
+    private func setupRegisterAlret() {
             let alert = UIAlertController(title: "登録できません", message: "チーム名、スコアを記入してください", preferredStyle: UIAlertController.Style.alert)
             alert.addAction(UIAlertAction(title: "戻る", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)

--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -39,7 +39,7 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     
     @IBAction func didTapRegisterButton(_ sender: UIButton) {
         if teamTextField.text!.isEmpty || myScoreTextField.text!.isEmpty || opponentScoreTextField.text!.isEmpty {
-            setupRegisterAlret()
+            showAlertInvalidRegister()
         } else {
             GameDataCreateModel.createGameData(gameDate: gameDatePicker.date,
                                                team: teamTextField.text ?? "",
@@ -52,7 +52,7 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
         }
     }
     
-    private func setupRegisterAlret() {
+    private func showAlertInvalidRegister() {
             let alert = UIAlertController(title: "登録できません", message: "チーム名、スコアを記入してください", preferredStyle: UIAlertController.Style.alert)
             alert.addAction(UIAlertAction(title: "戻る", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)

--- a/SoccerNoteApp/Model/GameDataDeleteModel.swift
+++ b/SoccerNoteApp/Model/GameDataDeleteModel.swift
@@ -1,0 +1,19 @@
+//
+//  GameDataDeleteModel.swift
+//  SoccerNoteApp
+//
+//  Created by hideto c. on 2021/02/08.
+//
+
+import Foundation
+import Firebase
+
+class GameDataDeleteModel {
+    
+    static func deleteGameData(indexPath: IndexPath, dataKey: String) {
+        let ref = Database.database().reference()
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        ref.child(uid).child(dataKey).removeValue()
+        GameDataModel.gameDataListArray.remove(at: indexPath.row)
+    }
+}


### PR DESCRIPTION
## clone コマンド
git clone -b feature/delete-game-data https://github.com/hidec-7/SoccerNoteDev.git

## Trello
CRUD(D:削除)

## 概要
試合管理画面でそれぞれのデータのCellをスワイプすると削除ができるように実装。

## レビューで見て欲しいポイント
自分の思いつく限りでdeleteの処理を書いて見ました。なので、良くない書き方など問題点があればご指摘お願いします。

スワイプした時の
![image](https://user-images.githubusercontent.com/66632738/107152585-0559e180-69ac-11eb-8511-775958a79207.png)
この「**delete**」の文字なんですけど、「**削除**」の日本語にした方がいいですかね？

## 実機build/期待通りの挙動をするか
 OK

## レビュー依頼 
@fuchi0741 