### PR TITLE
iPadのUIの崩れを修正

### DIFF
--- a/SoccerNoteApp/View/Base.lproj/LaunchScreen.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/LaunchScreen.storyboard
@@ -19,16 +19,16 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="AppLogo" translatesAutoresizingMaskIntoConstraints="NO" id="Ozq-RO-Z5X">
                                 <rect key="frame" x="32" y="363" width="350" height="170"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="170" id="Bhn-tI-0ws"/>
-                                    <constraint firstAttribute="width" constant="350" id="Wqu-oB-Utd"/>
+                                    <constraint firstAttribute="width" secondItem="Ozq-RO-Z5X" secondAttribute="height" multiplier="35:17" id="bgH-2z-DBz"/>
                                 </constraints>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="0.148248136" green="0.34580737350000001" blue="0.49532526729999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="Ozq-RO-Z5X" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Ddh-Ce-BIi"/>
-                            <constraint firstItem="Ozq-RO-Z5X" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="icG-ty-M4A"/>
+                            <constraint firstItem="Ozq-RO-Z5X" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Ddm-fz-hE7"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Ozq-RO-Z5X" secondAttribute="trailing" constant="32" id="QvY-QX-7mM"/>
+                            <constraint firstItem="Ozq-RO-Z5X" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="32" id="RKh-gD-dDW"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Qxw-je-PRi">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Qxw-je-PRi">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -256,32 +256,23 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vjp-or-C0h" userLabel="SlideMenuView">
-                                <rect key="frame" x="0.0" y="88" width="271" height="724"/>
+                                <rect key="frame" x="0.0" y="88" width="250" height="724"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EdV-hc-QTf" userLabel="LogoBackground">
-                                        <rect key="frame" x="0.0" y="0.0" width="271" height="60.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="250" height="55.666666666666664"/>
                                         <color key="backgroundColor" red="0.17787233329999999" green="0.31158018570000001" blue="0.40562260039999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="EdV-hc-QTf" secondAttribute="height" multiplier="9:2" id="G1i-TA-bLU"/>
+                                            <constraint firstAttribute="width" secondItem="EdV-hc-QTf" secondAttribute="height" multiplier="27:6" id="88b-C3-1Ya"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="AppLogo" translatesAutoresizingMaskIntoConstraints="NO" id="86r-7d-9q3">
-                                        <rect key="frame" x="55" y="8" width="161" height="44.666666666666664"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="86r-7d-9q3" secondAttribute="height" multiplier="18:5" id="mCf-ab-2Yt"/>
-                                        </constraints>
-                                    </imageView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="JKF-t0-8qD">
-                                        <rect key="frame" x="8" y="68.666666666666657" width="255" height="127.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="JKF-t0-8qD">
+                                        <rect key="frame" x="24" y="79.666666666666657" width="203" height="112.33333333333334"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uac-1Y-9pk">
-                                                <rect key="frame" x="0.0" y="0.0" width="255" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="HhF-Ey-77p"/>
-                                                </constraints>
+                                                <rect key="frame" x="0.0" y="0.0" width="203" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                 <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="1" maxY="0.0"/>
                                                 <state key="normal" title="ご意見・ご要望　　　　&gt;">
@@ -292,7 +283,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0kW-i6-aW7">
-                                                <rect key="frame" x="0.0" y="58" width="255" height="31"/>
+                                                <rect key="frame" x="0.0" y="41" width="203" height="31"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                 <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="10"/>
                                                 <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="1" maxY="0.0"/>
@@ -304,32 +295,37 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="アプリバージョン  　1.2.0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OHw-mf-W7i">
-                                                <rect key="frame" x="0.0" y="107.00000000000003" width="255" height="20.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="92.000000000000028" width="203" height="20.333333333333329"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                     </stackView>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="AppLogo" translatesAutoresizingMaskIntoConstraints="NO" id="86r-7d-9q3">
+                                        <rect key="frame" x="48" y="8" width="154" height="45.333333333333336"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="86r-7d-9q3" secondAttribute="height" multiplier="17:5" id="SIU-7s-9Nz"/>
+                                        </constraints>
+                                    </imageView>
                                 </subviews>
                                 <color key="backgroundColor" red="0.21001623743258171" green="0.36192725269928738" blue="0.46514621175437976" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstItem="86r-7d-9q3" firstAttribute="leading" secondItem="Vjp-or-C0h" secondAttribute="leading" constant="55" id="FL8-4z-vLc"/>
+                                    <constraint firstAttribute="trailing" secondItem="86r-7d-9q3" secondAttribute="trailing" constant="48" id="Ecq-Tm-42H"/>
                                     <constraint firstItem="EdV-hc-QTf" firstAttribute="leading" secondItem="Vjp-or-C0h" secondAttribute="leading" id="HVJ-Cb-g4J"/>
-                                    <constraint firstItem="JKF-t0-8qD" firstAttribute="top" secondItem="86r-7d-9q3" secondAttribute="bottom" constant="16" id="Pyt-pr-8yc"/>
-                                    <constraint firstAttribute="trailing" secondItem="EdV-hc-QTf" secondAttribute="trailing" id="Q7j-SH-teg"/>
-                                    <constraint firstAttribute="trailing" secondItem="JKF-t0-8qD" secondAttribute="trailing" constant="8" id="TKC-gz-0v9"/>
+                                    <constraint firstAttribute="trailing" secondItem="EdV-hc-QTf" secondAttribute="trailing" id="Nag-tz-6MK"/>
+                                    <constraint firstItem="JKF-t0-8qD" firstAttribute="leading" secondItem="Vjp-or-C0h" secondAttribute="leading" constant="24" id="Uuz-xm-bRw"/>
+                                    <constraint firstAttribute="width" constant="250" id="ffT-Gb-owj"/>
                                     <constraint firstItem="86r-7d-9q3" firstAttribute="top" secondItem="Vjp-or-C0h" secondAttribute="top" constant="8" id="gpd-fo-I5y"/>
-                                    <constraint firstItem="JKF-t0-8qD" firstAttribute="leading" secondItem="Vjp-or-C0h" secondAttribute="leading" constant="8" id="n7R-By-khK"/>
+                                    <constraint firstItem="86r-7d-9q3" firstAttribute="leading" secondItem="Vjp-or-C0h" secondAttribute="leading" constant="48" id="iRD-Hf-cPI"/>
                                     <constraint firstItem="EdV-hc-QTf" firstAttribute="top" secondItem="Vjp-or-C0h" secondAttribute="top" id="oq7-7e-Wbs"/>
-                                    <constraint firstAttribute="trailing" secondItem="86r-7d-9q3" secondAttribute="trailing" constant="55" id="orH-19-pnZ"/>
+                                    <constraint firstItem="JKF-t0-8qD" firstAttribute="top" secondItem="EdV-hc-QTf" secondAttribute="bottom" constant="24" id="puI-mR-c6n"/>
                                 </constraints>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="na0-0g-Kew"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="na0-0g-Kew" firstAttribute="trailing" secondItem="Vjp-or-C0h" secondAttribute="trailing" constant="104" id="3iI-Dv-t4C"/>
                             <constraint firstItem="Vjp-or-C0h" firstAttribute="top" secondItem="na0-0g-Kew" secondAttribute="top" constant="44" id="aya-Dm-Az3"/>
                             <constraint firstAttribute="bottom" secondItem="Vjp-or-C0h" secondAttribute="bottom" id="fZF-Dt-9WA"/>
                             <constraint firstItem="Vjp-or-C0h" firstAttribute="leading" secondItem="w6B-YH-egw" secondAttribute="leading" id="sYc-Oe-w5g"/>


### PR DESCRIPTION
## clone コマンド
git clone -b fix/UI-iPad https://github.com/hidec-7/MySoccerNoteApp.git

## 概要
iPadでUIのレイアウトが崩れていたのでオートレイアウトを修正

## 実機build/期待通りの挙動をするか
OK 

## 11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？
※UI変更した場合のみ記述
OK