### PR TITLE
試合編集画面 ViewにScrollView 追加実装

### DIFF
--- a/SoccerNoteApp/Controller/GameEditViewController.swift
+++ b/SoccerNoteApp/Controller/GameEditViewController.swift
@@ -88,7 +88,7 @@ class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigatio
     }
 
     private func setupEditButton() {
-        editButton.layer.cornerRadius = 15.0
+        editButton.layer.cornerRadius = 25.0
     }
 
     private func setupEditTextView() {

--- a/SoccerNoteApp/Controller/GameEditViewController.swift
+++ b/SoccerNoteApp/Controller/GameEditViewController.swift
@@ -12,6 +12,7 @@ class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigatio
     var gameData: GameDataModel?
 
     @IBOutlet private weak var gameEditNavigationBar: UINavigationBar!
+
     @IBOutlet private weak var gameEditDatePicker: UIDatePicker! {
         didSet {
             gameEditDatePicker.date = DateConverter.dateFromString(date: gameData?.gameDate ?? "") ?? gameEditDatePicker.date
@@ -24,30 +25,42 @@ class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigatio
     }
     @IBOutlet private weak var myScoreEditTextField: UITextField! {
         didSet {
+            myScoreEditTextField.keyboardType = UIKeyboardType.numberPad
             myScoreEditTextField.text = gameData?.myScore
         }
     }
     @IBOutlet private weak var opponentScoreEditTextField: UITextField! {
         didSet {
+            opponentScoreEditTextField.keyboardType = UIKeyboardType.numberPad
             opponentScoreEditTextField.text = gameData?.opponentScore
         }
     }
+
     @IBOutlet private weak var firstHalfEditTextView: UITextView! {
         didSet {
+            firstHalfEditTextView.layer.borderWidth = 1.2
             firstHalfEditTextView.text = gameData?.firstHalf
         }
     }
+
     @IBOutlet private weak var secondHalfEditTextView: UITextView! {
         didSet {
+            secondHalfEditTextView.layer.borderWidth = 1.2
             secondHalfEditTextView.text = gameData?.secondHalf
         }
     }
+
     @IBOutlet private weak var conclusionEditTextView: UITextView! {
         didSet {
+            conclusionEditTextView.layer.borderWidth = 1.2
             conclusionEditTextView.text = gameData?.conclusion
         }
     }
-    @IBOutlet private weak var editButton: UIButton!
+    @IBOutlet private weak var editButton: UIButton! {
+        didSet {
+            editButton.layer.cornerRadius = 25.0
+        }
+    }
 
     @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
@@ -60,8 +73,6 @@ class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigatio
         teamEditTextField.delegate = self
         myScoreEditTextField.delegate = self
         opponentScoreEditTextField.delegate = self
-
-        setupFirst()
     }
 
     @IBAction func didTapEditButton(_ sender: UIButton) {
@@ -74,27 +85,6 @@ class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigatio
                                            secondHalf: secondHalfEditTextView.text,
                                            conclusion: conclusionEditTextView.text)
         self.dismiss(animated: true, completion: nil)
-    }
-
-    private func setupFirst() {
-        setupKeyboard()
-        setupEditButton()
-        setupEditTextView()
-    }
-
-    private func setupKeyboard() {
-        myScoreEditTextField.keyboardType = UIKeyboardType.numberPad
-        opponentScoreEditTextField.keyboardType = UIKeyboardType.numberPad
-    }
-
-    private func setupEditButton() {
-        editButton.layer.cornerRadius = 25.0
-    }
-
-    private func setupEditTextView() {
-        firstHalfEditTextView.layer.borderWidth = 1.2
-        secondHalfEditTextView.layer.borderWidth = 1.2
-        conclusionEditTextView.layer.borderWidth = 1.2
     }
 
     func position(for bar: UIBarPositioning) -> UIBarPosition {

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -398,13 +398,13 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="772"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="試合日時" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
-                                                <rect key="frame" x="16" y="16" width="343" height="1"/>
-                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                <rect key="frame" x="16" y="15.999999999999998" width="343" height="3.6666666666666661"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
-                                                <rect key="frame" x="16" y="25.000000000000004" width="343" height="34.333333333333343"/>
+                                                <rect key="frame" x="16" y="27.666666666666675" width="343" height="34.333333333333343"/>
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="Jro-7s-hEf"/>
@@ -412,41 +412,44 @@
                                                 <locale key="locale" localeIdentifier="ja_JP"/>
                                             </datePicker>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="BSq-yI-X1g" userLabel="Game Data Edit Stack View">
-                                                <rect key="frame" x="16" y="75.333333333333343" width="343" height="72.666666666666657"/>
+                                                <rect key="frame" x="16" y="78" width="343" height="78"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MM1-b1-LUu" userLabel="Team Edit Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="34"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ygs-v4-BCY">
-                                                                <rect key="frame" x="0.0" y="0.0" width="32.333333333333336" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="33" height="34"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="22"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ke2-7z-oI5">
-                                                                <rect key="frame" x="48.333333333333343" y="0.0" width="294.66666666666663" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                                                <rect key="frame" x="49" y="0.0" width="294" height="34"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="ycG-9u-4q1" userLabel="Score Edit Stack View">
-                                                        <rect key="frame" x="0.0" y="41.333333333333314" width="343" height="31.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="44" width="343" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LqK-vz-phX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="34"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJp-JM-Oor">
-                                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
+                                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="34"/>
+                                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9Vv-ke-i6a">
-                                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="34"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
@@ -454,7 +457,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Edit Stack View">
-                                                <rect key="frame" x="16" y="164" width="343" height="480"/>
+                                                <rect key="frame" x="16" y="172" width="343" height="480"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Edit Stack View">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="153.33333333333334"/>
@@ -467,9 +470,9 @@
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rwk-OM-phs">
                                                                 <rect key="frame" x="0.0" y="20" width="343" height="133.33333333333334"/>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                             </textView>
                                                         </subviews>
@@ -485,9 +488,9 @@
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="5BQ-VF-aht">
                                                                 <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="133"/>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                             </textView>
                                                         </subviews>
@@ -503,9 +506,9 @@
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="8Pu-g6-wvP">
                                                                 <rect key="frame" x="0.0" y="20" width="343" height="133.33333333333334"/>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                             </textView>
                                                         </subviews>
@@ -513,7 +516,7 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7e9-3y-h75">
-                                                <rect key="frame" x="43.666666666666657" y="676" width="288" height="48"/>
+                                                <rect key="frame" x="43.666666666666657" y="684" width="288" height="48"/>
                                                 <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="7e9-3y-h75" secondAttribute="height" multiplier="6:1" id="VtR-mh-4dw"/>
@@ -542,7 +545,7 @@
                                             <constraint firstItem="BSq-yI-X1g" firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" id="iaZ-VO-VaN"/>
                                             <constraint firstItem="ZC7-ZI-fiY" firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" id="jsV-7K-uf9"/>
                                             <constraint firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" constant="16" id="oYM-1F-BlT"/>
-                                            <constraint firstAttribute="bottom" secondItem="7e9-3y-h75" secondAttribute="bottom" constant="48" id="pNK-x8-McS"/>
+                                            <constraint firstAttribute="bottom" secondItem="7e9-3y-h75" secondAttribute="bottom" constant="40" id="pNK-x8-McS"/>
                                             <constraint firstItem="7e9-3y-h75" firstAttribute="centerX" secondItem="dGY-cd-vEd" secondAttribute="centerX" id="qiH-7S-9IY"/>
                                             <constraint firstItem="2ie-Qz-tbo" firstAttribute="leading" secondItem="Ozy-lQ-h48" secondAttribute="leading" id="rEd-5R-AgU"/>
                                             <constraint firstItem="BSq-yI-X1g" firstAttribute="top" secondItem="2ie-Qz-tbo" secondAttribute="bottom" constant="16" id="sAI-Ei-mN1"/>
@@ -617,6 +620,9 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -397,7 +397,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dGY-cd-vEd" userLabel="Edit ContentsView">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="772"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  試合結果" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 試合結果" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
                                                 <rect key="frame" x="16" y="16" width="343" height="15.666666666666664"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                 <nil key="highlightedColor"/>

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -391,156 +391,184 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="試合日時" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
-                                <rect key="frame" x="16" y="96" width="343" height="20.333333333333329"/>
-                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
-                                <rect key="frame" x="16" y="124.33333333333333" width="343" height="34.333333333333329"/>
-                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="U1n-rU-sSs"/>
-                                </constraints>
-                                <locale key="locale" localeIdentifier="ja_JP"/>
-                            </datePicker>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="BSq-yI-X1g" userLabel="Game Data Edit Stack View">
-                                <rect key="frame" x="16" y="166.66666666666666" width="343" height="72.666666666666657"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8WY-HH-Nvi" userLabel="Game Edit Scroll View">
+                                <rect key="frame" x="0.0" y="88" width="375" height="724"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MM1-b1-LUu" userLabel="Team Edit Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dGY-cd-vEd" userLabel="Edit ContentsView">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="772"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ygs-v4-BCY">
-                                                <rect key="frame" x="0.0" y="0.0" width="32.333333333333336" height="31.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="試合日時" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
+                                                <rect key="frame" x="16" y="16" width="343" height="1"/>
+                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ke2-7z-oI5">
-                                                <rect key="frame" x="48.333333333333343" y="0.0" width="294.66666666666663" height="31.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
+                                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
+                                                <rect key="frame" x="16" y="25.000000000000004" width="343" height="34.333333333333343"/>
+                                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="Jro-7s-hEf"/>
+                                                </constraints>
+                                                <locale key="locale" localeIdentifier="ja_JP"/>
+                                            </datePicker>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="BSq-yI-X1g" userLabel="Game Data Edit Stack View">
+                                                <rect key="frame" x="16" y="75.333333333333343" width="343" height="72.666666666666657"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MM1-b1-LUu" userLabel="Team Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ygs-v4-BCY">
+                                                                <rect key="frame" x="0.0" y="0.0" width="32.333333333333336" height="31.333333333333332"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ke2-7z-oI5">
+                                                                <rect key="frame" x="48.333333333333343" y="0.0" width="294.66666666666663" height="31.333333333333332"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="ycG-9u-4q1" userLabel="Score Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="41.333333333333314" width="343" height="31.333333333333329"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LqK-vz-phX">
+                                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="31.333333333333332"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJp-JM-Oor">
+                                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9Vv-ke-i6a">
+                                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Edit Stack View">
+                                                <rect key="frame" x="16" y="164" width="343" height="480"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="153.33333333333334"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-xk-bQn">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rwk-OM-phs">
+                                                                <rect key="frame" x="0.0" y="20" width="343" height="133.33333333333334"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="textColor" systemColor="labelColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                            </textView>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="163.33333333333331" width="343" height="153.33333333333331"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62z-tK-ZeX">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="5BQ-VF-aht">
+                                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="133"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="textColor" systemColor="labelColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                            </textView>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="326.66666666666663" width="343" height="153.33333333333337"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0I-rJ-K6Y">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="8Pu-g6-wvP">
+                                                                <rect key="frame" x="0.0" y="20" width="343" height="133.33333333333334"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="textColor" systemColor="labelColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                            </textView>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7e9-3y-h75">
+                                                <rect key="frame" x="43.666666666666657" y="676" width="288" height="48"/>
+                                                <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="7e9-3y-h75" secondAttribute="height" multiplier="6:1" id="VtR-mh-4dw"/>
+                                                    <constraint firstAttribute="height" constant="48" id="jjy-9H-kUx"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
+                                                <state key="normal" title="登録">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="didTapEditButton:" destination="dYk-Ue-BcU" eventType="touchUpInside" id="WxC-cV-9M4"/>
+                                                    <action selector="didTapRegisterButton:" destination="rP5-fx-GU0" eventType="touchUpInside" id="hcc-uo-0NG"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="ycG-9u-4q1" userLabel="Score Edit Stack View">
-                                        <rect key="frame" x="0.0" y="41.333333333333343" width="343" height="31.333333333333329"/>
-                                        <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LqK-vz-phX">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="31.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJp-JM-Oor">
-                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9Vv-ke-i6a">
-                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                        </subviews>
-                                    </stackView>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="BSq-yI-X1g" firstAttribute="leading" secondItem="Ozy-lQ-h48" secondAttribute="leading" id="47Y-IU-htJ"/>
+                                            <constraint firstItem="Ozy-lQ-h48" firstAttribute="leading" secondItem="dGY-cd-vEd" secondAttribute="leading" constant="16" id="8Ar-0d-aW8"/>
+                                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="top" secondItem="BSq-yI-X1g" secondAttribute="bottom" constant="16" id="8At-6m-OAl"/>
+                                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="leading" secondItem="Ozy-lQ-h48" secondAttribute="leading" id="BuV-rr-EGx"/>
+                                            <constraint firstItem="Ozy-lQ-h48" firstAttribute="top" secondItem="dGY-cd-vEd" secondAttribute="top" constant="16" id="ePT-xG-hR3"/>
+                                            <constraint firstAttribute="height" constant="772" id="f0w-5A-Trs"/>
+                                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" id="gM4-fO-lLd"/>
+                                            <constraint firstItem="7e9-3y-h75" firstAttribute="top" secondItem="ZC7-ZI-fiY" secondAttribute="bottom" constant="32" id="ggH-3Q-5Ah"/>
+                                            <constraint firstItem="BSq-yI-X1g" firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" id="iaZ-VO-VaN"/>
+                                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" id="jsV-7K-uf9"/>
+                                            <constraint firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" constant="16" id="oYM-1F-BlT"/>
+                                            <constraint firstAttribute="bottom" secondItem="7e9-3y-h75" secondAttribute="bottom" constant="48" id="pNK-x8-McS"/>
+                                            <constraint firstItem="7e9-3y-h75" firstAttribute="centerX" secondItem="dGY-cd-vEd" secondAttribute="centerX" id="qiH-7S-9IY"/>
+                                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="leading" secondItem="Ozy-lQ-h48" secondAttribute="leading" id="rEd-5R-AgU"/>
+                                            <constraint firstItem="BSq-yI-X1g" firstAttribute="top" secondItem="2ie-Qz-tbo" secondAttribute="bottom" constant="16" id="sAI-Ei-mN1"/>
+                                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Ozy-lQ-h48" secondAttribute="bottom" constant="8" id="yC2-Bt-KVx"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
-                            </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Edit Stack View">
-                                <rect key="frame" x="16" y="247.33333333333337" width="343" height="465"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Edit Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="148.33333333333334"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-xk-bQn">
-                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rwk-OM-phs">
-                                                <rect key="frame" x="0.0" y="20.333333333333343" width="343" height="128"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <color key="textColor" systemColor="labelColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            </textView>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Edit Stack View">
-                                        <rect key="frame" x="0.0" y="158.33333333333331" width="343" height="148.33333333333331"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62z-tK-ZeX">
-                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="5BQ-VF-aht">
-                                                <rect key="frame" x="0.0" y="20.333333333333314" width="343" height="128"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <color key="textColor" systemColor="labelColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            </textView>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Edit Stack View">
-                                        <rect key="frame" x="0.0" y="316.66666666666663" width="343" height="148.33333333333337"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0I-rJ-K6Y">
-                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="8Pu-g6-wvP">
-                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="128"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <color key="textColor" systemColor="labelColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            </textView>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                            </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7e9-3y-h75">
-                                <rect key="frame" x="142.66666666666666" y="736.33333333333337" width="89.666666666666657" height="33.666666666666629"/>
-                                <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="7e9-3y-h75" secondAttribute="height" multiplier="8:3" id="Txy-bU-cAy"/>
+                                    <constraint firstItem="dGY-cd-vEd" firstAttribute="top" secondItem="Tjd-As-yWf" secondAttribute="top" id="5qh-R6-drG"/>
+                                    <constraint firstItem="dGY-cd-vEd" firstAttribute="trailing" secondItem="Tjd-As-yWf" secondAttribute="trailing" id="Rbh-oC-mfa"/>
+                                    <constraint firstItem="dGY-cd-vEd" firstAttribute="bottom" secondItem="Tjd-As-yWf" secondAttribute="bottom" id="hhC-Nz-yrd"/>
+                                    <constraint firstItem="dGY-cd-vEd" firstAttribute="width" secondItem="WU5-Bz-HPT" secondAttribute="width" id="iV3-NR-iT0"/>
+                                    <constraint firstItem="dGY-cd-vEd" firstAttribute="leading" secondItem="Tjd-As-yWf" secondAttribute="leading" id="k5G-Ky-bZe"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
-                                <state key="normal" title="登録">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <connections>
-                                    <action selector="didTapEditButton:" destination="dYk-Ue-BcU" eventType="touchUpInside" id="WxC-cV-9M4"/>
-                                    <action selector="didTapRegisterButton:" destination="rP5-fx-GU0" eventType="touchUpInside" id="hcc-uo-0NG"/>
-                                </connections>
-                            </button>
+                                <viewLayoutGuide key="contentLayoutGuide" id="Tjd-As-yWf"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="WU5-Bz-HPT"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6pS-Ur-o3u"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="trailing" secondItem="Ozy-lQ-h48" secondAttribute="trailing" id="0Rw-zL-ELf"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" id="0X6-cU-OFG"/>
-                            <constraint firstItem="Ozy-lQ-h48" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" constant="8" id="4JK-XJ-4QE"/>
-                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="centerX" secondItem="BSq-yI-X1g" secondAttribute="centerX" id="6bI-10-2mt"/>
-                            <constraint firstItem="BSq-yI-X1g" firstAttribute="top" secondItem="2ie-Qz-tbo" secondAttribute="bottom" constant="8" id="JaH-V1-nqA"/>
-                            <constraint firstItem="BSq-yI-X1g" firstAttribute="centerX" secondItem="2ie-Qz-tbo" secondAttribute="centerX" id="KAw-Fn-Ch6"/>
-                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="top" secondItem="Ozy-lQ-h48" secondAttribute="bottom" constant="8" id="OUk-0a-MHb"/>
-                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="leading" secondItem="6pS-Ur-o3u" secondAttribute="leading" constant="16" id="OwP-X8-qgH"/>
-                            <constraint firstItem="2ie-Qz-tbo" firstAttribute="leading" secondItem="Ozy-lQ-h48" secondAttribute="leading" id="UuK-B0-AdI"/>
-                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="top" secondItem="BSq-yI-X1g" secondAttribute="bottom" constant="8" id="cbe-nB-ag9"/>
-                            <constraint firstItem="BSq-yI-X1g" firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="width" id="dBo-tg-e2d"/>
-                            <constraint firstItem="ZC7-ZI-fiY" firstAttribute="width" secondItem="BSq-yI-X1g" secondAttribute="width" id="giv-zX-N7C"/>
-                            <constraint firstItem="6pS-Ur-o3u" firstAttribute="bottom" secondItem="7e9-3y-h75" secondAttribute="bottom" constant="8" id="kaO-Ai-EvH"/>
-                            <constraint firstItem="7e9-3y-h75" firstAttribute="centerX" secondItem="ZC7-ZI-fiY" secondAttribute="centerX" id="nud-uL-a0d"/>
-                            <constraint firstItem="7e9-3y-h75" firstAttribute="top" secondItem="ZC7-ZI-fiY" secondAttribute="bottom" constant="24" id="o0b-P5-8us"/>
-                            <constraint firstItem="6pS-Ur-o3u" firstAttribute="trailing" secondItem="2ie-Qz-tbo" secondAttribute="trailing" constant="16" id="ozm-Bf-y0K"/>
+                            <constraint firstItem="8WY-HH-Nvi" firstAttribute="leading" secondItem="mLL-cd-pzF" secondAttribute="leading" id="1yi-Gs-oaR"/>
+                            <constraint firstAttribute="bottom" secondItem="8WY-HH-Nvi" secondAttribute="bottom" id="Cuz-l1-RoB"/>
+                            <constraint firstItem="8WY-HH-Nvi" firstAttribute="top" secondItem="Z06-EE-D7X" secondAttribute="bottom" id="P07-g6-9dd"/>
+                            <constraint firstAttribute="trailing" secondItem="8WY-HH-Nvi" secondAttribute="trailing" id="Z2P-BN-Yzq"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="top" secondItem="6pS-Ur-o3u" secondAttribute="top" id="sNG-g7-9yZ"/>
                             <constraint firstItem="Z06-EE-D7X" firstAttribute="trailing" secondItem="6pS-Ur-o3u" secondAttribute="trailing" id="tKI-PC-uas"/>
                         </constraints>

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -397,14 +397,13 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dGY-cd-vEd" userLabel="Edit ContentsView">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="772"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="試合日時" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
-                                                <rect key="frame" x="16" y="15.999999999999998" width="343" height="3.6666666666666661"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
-                                                <nil key="textColor"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  試合結果" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
+                                                <rect key="frame" x="16" y="16" width="343" height="15.666666666666664"/>
+                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
-                                                <rect key="frame" x="16" y="27.666666666666675" width="343" height="34.333333333333343"/>
+                                                <rect key="frame" x="16" y="39.666666666666671" width="343" height="34.333333333333329"/>
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="Jro-7s-hEf"/>
@@ -412,7 +411,7 @@
                                                 <locale key="locale" localeIdentifier="ja_JP"/>
                                             </datePicker>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="BSq-yI-X1g" userLabel="Game Data Edit Stack View">
-                                                <rect key="frame" x="16" y="78" width="343" height="78"/>
+                                                <rect key="frame" x="16" y="90" width="343" height="78"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MM1-b1-LUu" userLabel="Team Edit Stack View">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="34"/>
@@ -457,19 +456,18 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZC7-ZI-fiY" userLabel="Impression Edit Stack View">
-                                                <rect key="frame" x="16" y="172" width="343" height="480"/>
+                                                <rect key="frame" x="16" y="184" width="343" height="468"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Edit Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="153.33333333333334"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="j6P-b8-UHv" userLabel="First Half Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="149.33333333333334"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-xk-bQn">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                                                <nil key="textColor"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-xk-bQn">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="19"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rwk-OM-phs">
-                                                                <rect key="frame" x="0.0" y="20" width="343" height="133.33333333333334"/>
+                                                                <rect key="frame" x="0.0" y="23.999999999999993" width="343" height="125.33333333333331"/>
                                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -477,17 +475,16 @@
                                                             </textView>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Edit Stack View">
-                                                        <rect key="frame" x="0.0" y="163.33333333333331" width="343" height="153.33333333333331"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="HAQ-Qf-Ltx" userLabel="Sencond Half Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="159.33333333333331" width="343" height="149.33333333333331"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62z-tK-ZeX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                                                <nil key="textColor"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62z-tK-ZeX">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="23"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="5BQ-VF-aht">
-                                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="133"/>
+                                                                <rect key="frame" x="0.0" y="27.999999999999993" width="343" height="121.33333333333331"/>
                                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -495,17 +492,16 @@
                                                             </textView>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Edit Stack View">
-                                                        <rect key="frame" x="0.0" y="326.66666666666663" width="343" height="153.33333333333337"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="n5r-Lv-nsl" userLabel="All Edit Stack View">
+                                                        <rect key="frame" x="0.0" y="318.66666666666663" width="343" height="149.33333333333337"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0I-rJ-K6Y">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                                                <nil key="textColor"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0I-rJ-K6Y">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="23"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="8Pu-g6-wvP">
-                                                                <rect key="frame" x="0.0" y="20" width="343" height="133.33333333333334"/>
+                                                                <rect key="frame" x="0.0" y="27.999999999999993" width="343" height="121.33333333333331"/>
                                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -517,7 +513,7 @@
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7e9-3y-h75">
                                                 <rect key="frame" x="43.666666666666657" y="684" width="288" height="48"/>
-                                                <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" red="0.148248136" green="0.34580737350000001" blue="0.49532526729999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="7e9-3y-h75" secondAttribute="height" multiplier="6:1" id="VtR-mh-4dw"/>
                                                     <constraint firstAttribute="height" constant="48" id="jjy-9H-kUx"/>


### PR DESCRIPTION
## clone コマンド
git clone -b feature/add-scrollView-gameEditVC https://github.com/hidec-7/MySoccerNoteApp.git

## 概要
試合編集画面のViewをスクロールできるように、ScrollViewを実装
- スクロールできるように変更したことで、キーボードを表示した時にNavigationBarを固定してViewだけ上げることが可能
- それぞれのアイテムが窮屈になっていたが、余裕ができるようになった

- 多少のスクロールをして登録ボタンを押さないといけないという手間がデメリットでもある。

## 実機build/期待通りの挙動をするか
OK

## 11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？
OK