### PR TITLE
試合登録画面 UIの軽微な変更とリファクタリング

### DIFF
--- a/SoccerNoteApp/Controller/GameEditViewController.swift
+++ b/SoccerNoteApp/Controller/GameEditViewController.swift
@@ -35,21 +35,18 @@ class GameEditViewController: UIViewController, UITextFieldDelegate, UINavigatio
             opponentScoreEditTextField.text = gameData?.opponentScore
         }
     }
-
     @IBOutlet private weak var firstHalfEditTextView: UITextView! {
         didSet {
             firstHalfEditTextView.layer.borderWidth = 1.2
             firstHalfEditTextView.text = gameData?.firstHalf
         }
     }
-
     @IBOutlet private weak var secondHalfEditTextView: UITextView! {
         didSet {
             secondHalfEditTextView.layer.borderWidth = 1.2
             secondHalfEditTextView.text = gameData?.secondHalf
         }
     }
-
     @IBOutlet private weak var conclusionEditTextView: UITextView! {
         didSet {
             conclusionEditTextView.layer.borderWidth = 1.2

--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -65,7 +65,7 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     }
 
     private func setupRegisterButton() {
-        registerButton.layer.cornerRadius = 18
+        registerButton.layer.cornerRadius = 25.0
     }
 
     private func setupTextView() {

--- a/SoccerNoteApp/Controller/GameRegisterViewController.swift
+++ b/SoccerNoteApp/Controller/GameRegisterViewController.swift
@@ -15,12 +15,36 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
     @IBOutlet private weak var gameNavigationBar: UINavigationBar!
     @IBOutlet private weak var gameDatePicker: UIDatePicker!
     @IBOutlet private weak var teamTextField: UITextField!
-    @IBOutlet private weak var myScoreTextField: UITextField!
-    @IBOutlet private weak var opponentScoreTextField: UITextField!
-    @IBOutlet private weak var firstHalfTextView: UITextView!
-    @IBOutlet private weak var secondHalfTextView: UITextView!
-    @IBOutlet private weak var conclusionTextView: UITextView!
-    @IBOutlet private weak var registerButton: UIButton!
+    @IBOutlet private weak var myScoreTextField: UITextField! {
+        didSet {
+            myScoreTextField.keyboardType = UIKeyboardType.numberPad
+        }
+    }
+    @IBOutlet private weak var opponentScoreTextField: UITextField! {
+        didSet {
+            opponentScoreTextField.keyboardType = UIKeyboardType.numberPad
+        }
+    }
+    @IBOutlet private weak var firstHalfTextView: UITextView! {
+        didSet {
+            firstHalfTextView.layer.borderWidth = 1.2
+        }
+    }
+    @IBOutlet private weak var secondHalfTextView: UITextView! {
+        didSet {
+            secondHalfTextView.layer.borderWidth = 1.2
+        }
+    }
+    @IBOutlet private weak var conclusionTextView: UITextView! {
+        didSet {
+            conclusionTextView.layer.borderWidth = 1.2
+        }
+    }
+    @IBOutlet private weak var registerButton: UIButton! {
+        didSet {
+            registerButton.layer.cornerRadius = 25.0
+        }
+    }
 
     @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
@@ -33,8 +57,6 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
         teamTextField.delegate = self
         myScoreTextField.delegate = self
         opponentScoreTextField.delegate = self
-
-        setupFirst()
     }
 
     @IBAction func didTapRegisterButton(_ sender: UIButton) {
@@ -58,29 +80,8 @@ class GameRegisterViewController: UIViewController, UITextFieldDelegate, UINavig
         present(alert, animated: true, completion: nil)
     }
 
-    private func setupFirst() {
-        setupRegisterButton()
-        setupTextView()
-        setupKeyboard()
-    }
-
-    private func setupRegisterButton() {
-        registerButton.layer.cornerRadius = 25.0
-    }
-
-    private func setupTextView() {
-        firstHalfTextView.layer.borderWidth = 1.2
-        secondHalfTextView.layer.borderWidth = 1.2
-        conclusionTextView.layer.borderWidth = 1.2
-    }
-
     func position(for bar: UIBarPositioning) -> UIBarPosition {
         .topAttached
-    }
-
-    private func setupKeyboard() {
-        self.myScoreTextField.keyboardType = UIKeyboardType.numberPad
-        self.opponentScoreTextField.keyboardType = UIKeyboardType.numberPad
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -81,16 +81,16 @@
                                 <rect key="frame" x="0.0" y="88" width="375" height="724"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pcQ-qO-HYh" userLabel="Game Contents View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="880"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="772"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="試合日時" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4oc-eK-YPb" userLabel="Game Date Label">
-                                                <rect key="frame" x="16" y="15.999999999999998" width="343" height="20.333333333333329"/>
+                                                <rect key="frame" x="16" y="16" width="343" height="8"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
-                                                <rect key="frame" x="16" y="44.333333333333343" width="343" height="34.333333333333343"/>
+                                                <rect key="frame" x="16" y="32" width="343" height="34.333333333333343"/>
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="10:1" id="EHs-Qr-KGF"/>
@@ -98,7 +98,7 @@
                                                 <locale key="locale" localeIdentifier="ja_JP"/>
                                             </datePicker>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1" userLabel="Game Data Stack View">
-                                                <rect key="frame" x="16" y="102.66666666666666" width="343" height="72.666666666666657"/>
+                                                <rect key="frame" x="16" y="82.333333333333343" width="343" height="72.666666666666657"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT" userLabel="Team Stack View">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
@@ -117,7 +117,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-jX-70f" userLabel="Score Stack View">
-                                                        <rect key="frame" x="0.0" y="41.333333333333343" width="343" height="31.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="41.333333333333314" width="343" height="31.333333333333329"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i39-ld-Wyn">
                                                                 <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="31.333333333333332"/>
@@ -140,19 +140,19 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="3lk-kU-cIY" userLabel="Impression Stack View">
-                                                <rect key="frame" x="16" y="199.33333333333331" width="343" height="596"/>
+                                                <rect key="frame" x="16" y="171" width="343" height="481"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aX0-Y7-CQv" userLabel="First Half Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="192"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="153.66666666666666"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O1G-XQ-wZg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ZUY-7G-0EB">
-                                                                <rect key="frame" x="0.0" y="20" width="343" height="172"/>
+                                                                <rect key="frame" x="0.0" y="20.333333333333314" width="343" height="133.33333333333334"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -161,7 +161,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zFD-fJ-wZx" userLabel="Sencond Half Stack View">
-                                                        <rect key="frame" x="0.0" y="202" width="343" height="192"/>
+                                                        <rect key="frame" x="0.0" y="163.66666666666669" width="343" height="153.66666666666669"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hfB-Ml-wpG">
                                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
@@ -170,7 +170,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="AM9-Fv-Aa6">
-                                                                <rect key="frame" x="0.0" y="20.333333333333371" width="343" height="171.66666666666666"/>
+                                                                <rect key="frame" x="0.0" y="20.333333333333314" width="343" height="133.33333333333334"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -179,16 +179,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="syE-lO-Eli" userLabel="All Stack View">
-                                                        <rect key="frame" x="0.0" y="404.00000000000006" width="343" height="191.99999999999994"/>
+                                                        <rect key="frame" x="0.0" y="327.33333333333337" width="343" height="153.66666666666663"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uka-XJ-nVH">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3gj-Dt-Bve">
-                                                                <rect key="frame" x="0.0" y="20" width="343" height="172"/>
+                                                                <rect key="frame" x="0.0" y="20.333333333333258" width="343" height="133.33333333333334"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -199,10 +199,11 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kJn-No-Q5j">
-                                                <rect key="frame" x="151.33333333333334" y="827.33333333333337" width="72.333333333333343" height="20.666666666666629"/>
+                                                <rect key="frame" x="43.666666666666657" y="684" width="288" height="48"/>
                                                 <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" secondItem="kJn-No-Q5j" secondAttribute="height" multiplier="7:2" id="Y4z-Pe-Wtu"/>
+                                                    <constraint firstAttribute="height" constant="48" id="SS5-Lh-6bO"/>
+                                                    <constraint firstAttribute="width" secondItem="kJn-No-Q5j" secondAttribute="height" multiplier="6:1" id="Y4z-Pe-Wtu"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                                 <state key="normal" title="登録">
@@ -215,30 +216,28 @@
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
+                                            <constraint firstItem="3lk-kU-cIY" firstAttribute="trailing" secondItem="4oc-eK-YPb" secondAttribute="trailing" id="1WN-6h-79y"/>
                                             <constraint firstItem="3Kg-3u-GOy" firstAttribute="top" secondItem="4oc-eK-YPb" secondAttribute="bottom" constant="8" id="63l-na-d1k"/>
                                             <constraint firstItem="4oc-eK-YPb" firstAttribute="top" secondItem="pcQ-qO-HYh" secondAttribute="top" constant="16" id="8Kd-es-e8h"/>
-                                            <constraint firstAttribute="bottom" secondItem="kJn-No-Q5j" secondAttribute="bottom" constant="32" id="BqS-fB-VLS"/>
+                                            <constraint firstAttribute="bottom" secondItem="kJn-No-Q5j" secondAttribute="bottom" constant="40" id="BqS-fB-VLS"/>
                                             <constraint firstItem="4oc-eK-YPb" firstAttribute="leading" secondItem="pcQ-qO-HYh" secondAttribute="leading" constant="16" id="FEF-9A-65S"/>
-                                            <constraint firstItem="3lk-kU-cIY" firstAttribute="top" secondItem="1Pj-GZ-yV1" secondAttribute="bottom" constant="24" id="GTd-TU-rbd"/>
-                                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="top" secondItem="3Kg-3u-GOy" secondAttribute="bottom" constant="24" id="JMG-qB-fnh"/>
-                                            <constraint firstItem="3lk-kU-cIY" firstAttribute="trailing" secondItem="1Pj-GZ-yV1" secondAttribute="trailing" id="Kha-r9-7JD"/>
-                                            <constraint firstItem="3lk-kU-cIY" firstAttribute="leading" secondItem="1Pj-GZ-yV1" secondAttribute="leading" id="NmG-b5-OTg"/>
+                                            <constraint firstItem="3lk-kU-cIY" firstAttribute="top" secondItem="1Pj-GZ-yV1" secondAttribute="bottom" constant="16" id="GTd-TU-rbd"/>
+                                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="top" secondItem="3Kg-3u-GOy" secondAttribute="bottom" constant="16" id="JMG-qB-fnh"/>
                                             <constraint firstAttribute="trailing" secondItem="4oc-eK-YPb" secondAttribute="trailing" constant="16" id="TVh-n2-7sS"/>
+                                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="trailing" secondItem="4oc-eK-YPb" secondAttribute="trailing" id="UDz-ob-B9t"/>
                                             <constraint firstItem="kJn-No-Q5j" firstAttribute="top" secondItem="3lk-kU-cIY" secondAttribute="bottom" constant="32" id="ac6-qF-gya"/>
-                                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="leading" secondItem="3Kg-3u-GOy" secondAttribute="leading" id="bqe-G5-pY1"/>
                                             <constraint firstItem="3Kg-3u-GOy" firstAttribute="trailing" secondItem="4oc-eK-YPb" secondAttribute="trailing" id="d7N-3c-B72"/>
                                             <constraint firstItem="3Kg-3u-GOy" firstAttribute="leading" secondItem="4oc-eK-YPb" secondAttribute="leading" id="fkh-hG-IvY"/>
-                                            <constraint firstAttribute="height" constant="880" id="kdl-yF-N2e"/>
+                                            <constraint firstItem="3lk-kU-cIY" firstAttribute="leading" secondItem="4oc-eK-YPb" secondAttribute="leading" id="ju2-9Y-2O7"/>
+                                            <constraint firstAttribute="height" constant="772" id="kdl-yF-N2e"/>
                                             <constraint firstItem="kJn-No-Q5j" firstAttribute="centerX" secondItem="pcQ-qO-HYh" secondAttribute="centerX" id="sSU-zd-wne"/>
-                                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="trailing" secondItem="3Kg-3u-GOy" secondAttribute="trailing" id="v9h-q1-bMs"/>
+                                            <constraint firstItem="1Pj-GZ-yV1" firstAttribute="leading" secondItem="4oc-eK-YPb" secondAttribute="leading" id="to2-rF-wjp"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="pcQ-qO-HYh" firstAttribute="width" secondItem="hsv-Xk-efK" secondAttribute="width" id="Btl-ja-tnQ"/>
-                                    <constraint firstItem="pcQ-qO-HYh" firstAttribute="top" secondItem="hsv-Xk-efK" secondAttribute="top" id="LYg-Jj-9Zk"/>
                                     <constraint firstItem="pcQ-qO-HYh" firstAttribute="trailing" secondItem="8eY-hh-RmA" secondAttribute="trailing" id="UfB-eD-lGF"/>
-                                    <constraint firstItem="pcQ-qO-HYh" firstAttribute="top" secondItem="hsv-Xk-efK" secondAttribute="top" id="XHw-x0-fJR"/>
                                     <constraint firstItem="pcQ-qO-HYh" firstAttribute="leading" secondItem="8eY-hh-RmA" secondAttribute="leading" id="nOH-RZ-ahw"/>
                                     <constraint firstItem="pcQ-qO-HYh" firstAttribute="bottom" secondItem="8eY-hh-RmA" secondAttribute="bottom" id="osl-VB-23K"/>
                                     <constraint firstItem="pcQ-qO-HYh" firstAttribute="top" secondItem="8eY-hh-RmA" secondAttribute="top" id="uZz-Ff-Ytp"/>

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -111,6 +111,7 @@
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HMf-mO-THt">
                                                                 <rect key="frame" x="49" y="0.0" width="294" height="35"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
@@ -121,6 +122,7 @@
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i39-ld-Wyn">
                                                                 <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="35"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
@@ -132,6 +134,7 @@
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u5l-uM-MaY">
                                                                 <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="35"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
@@ -153,7 +156,7 @@
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ZUY-7G-0EB">
                                                                 <rect key="frame" x="0.0" y="25.666666666666686" width="343" height="128.33333333333334"/>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -171,7 +174,7 @@
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="AM9-Fv-Aa6">
                                                                 <rect key="frame" x="0.0" y="25.333333333333371" width="343" height="128.33333333333334"/>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -189,7 +192,7 @@
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3gj-Dt-Bve">
                                                                 <rect key="frame" x="0.0" y="25.666666666666629" width="343" height="128.33333333333334"/>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -515,7 +515,7 @@
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7e9-3y-h75">
                                                 <rect key="frame" x="43.666666666666657" y="684" width="288" height="48"/>
-                                                <color key="backgroundColor" red="0.148248136" green="0.34580737350000001" blue="0.49532526729999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" red="0.25951080180000002" green="0.44316002090000001" blue="0.5641634995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="7e9-3y-h75" secondAttribute="height" multiplier="6:1" id="VtR-mh-4dw"/>
                                                     <constraint firstAttribute="height" constant="48" id="jjy-9H-kUx"/>

--- a/SoccerNoteApp/View/Base.lproj/Main.storyboard
+++ b/SoccerNoteApp/View/Base.lproj/Main.storyboard
@@ -83,14 +83,14 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pcQ-qO-HYh" userLabel="Game Contents View">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="772"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="試合日時" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4oc-eK-YPb" userLabel="Game Date Label">
-                                                <rect key="frame" x="16" y="16" width="343" height="8"/>
-                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 試合結果" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4oc-eK-YPb" userLabel="Game Date Label">
+                                                <rect key="frame" x="16" y="16" width="343" height="0.0"/>
+                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="3Kg-3u-GOy">
-                                                <rect key="frame" x="16" y="32" width="343" height="34.333333333333343"/>
+                                                <rect key="frame" x="16" y="24.000000000000004" width="343" height="34.333333333333343"/>
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="3Kg-3u-GOy" secondAttribute="height" multiplier="10:1" id="EHs-Qr-KGF"/>
@@ -98,41 +98,41 @@
                                                 <locale key="locale" localeIdentifier="ja_JP"/>
                                             </datePicker>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-GZ-yV1" userLabel="Game Data Stack View">
-                                                <rect key="frame" x="16" y="82.333333333333343" width="343" height="72.666666666666657"/>
+                                                <rect key="frame" x="16" y="74.333333333333343" width="343" height="80"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TTt-Tu-3dT" userLabel="Team Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="31.333333333333332"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="35"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O90-28-gsI">
-                                                                <rect key="frame" x="0.0" y="0.0" width="32.333333333333336" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="33" height="35"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="22"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HMf-mO-THt">
-                                                                <rect key="frame" x="48.333333333333343" y="0.0" width="294.66666666666663" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                                                <rect key="frame" x="49" y="0.0" width="294" height="35"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-jX-70f" userLabel="Score Stack View">
-                                                        <rect key="frame" x="0.0" y="41.333333333333314" width="343" height="31.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="45" width="343" height="35"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i39-ld-Wyn">
-                                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="35"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="17j-g8-Pin">
-                                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
+                                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="35"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u5l-uM-MaY">
-                                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="31.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="35"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
@@ -140,19 +140,19 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="3lk-kU-cIY" userLabel="Impression Stack View">
-                                                <rect key="frame" x="16" y="171" width="343" height="481"/>
+                                                <rect key="frame" x="16" y="170.33333333333329" width="343" height="481.66666666666674"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aX0-Y7-CQv" userLabel="First Half Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="153.66666666666666"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="aX0-Y7-CQv" userLabel="First Half Stack View">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="154"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O1G-XQ-wZg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 前半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O1G-XQ-wZg">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.666666666666668"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ZUY-7G-0EB">
-                                                                <rect key="frame" x="0.0" y="20.333333333333314" width="343" height="133.33333333333334"/>
+                                                                <rect key="frame" x="0.0" y="25.666666666666686" width="343" height="128.33333333333334"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -160,17 +160,17 @@
                                                             </textView>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zFD-fJ-wZx" userLabel="Sencond Half Stack View">
-                                                        <rect key="frame" x="0.0" y="163.66666666666669" width="343" height="153.66666666666669"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="zFD-fJ-wZx" userLabel="Sencond Half Stack View">
+                                                        <rect key="frame" x="0.0" y="164" width="343" height="153.66666666666663"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hfB-Ml-wpG">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 後半" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hfB-Ml-wpG">
                                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="AM9-Fv-Aa6">
-                                                                <rect key="frame" x="0.0" y="20.333333333333314" width="343" height="133.33333333333334"/>
+                                                                <rect key="frame" x="0.0" y="25.333333333333371" width="343" height="128.33333333333334"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -178,17 +178,17 @@
                                                             </textView>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="syE-lO-Eli" userLabel="All Stack View">
-                                                        <rect key="frame" x="0.0" y="327.33333333333337" width="343" height="153.66666666666663"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="syE-lO-Eli" userLabel="All Stack View">
+                                                        <rect key="frame" x="0.0" y="327.66666666666669" width="343" height="154"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uka-XJ-nVH">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.333333333333332"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" まとめ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uka-XJ-nVH">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.666666666666668"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3gj-Dt-Bve">
-                                                                <rect key="frame" x="0.0" y="20.333333333333258" width="343" height="133.33333333333334"/>
+                                                                <rect key="frame" x="0.0" y="25.666666666666629" width="343" height="128.33333333333334"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <color key="textColor" systemColor="labelColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -397,12 +397,12 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="772"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 試合結果" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ozy-lQ-h48" userLabel="Game Edit Date Label">
-                                                <rect key="frame" x="16" y="16" width="343" height="15.666666666666664"/>
+                                                <rect key="frame" x="16" y="16" width="343" height="13.666666666666664"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="5" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-Qz-tbo">
-                                                <rect key="frame" x="16" y="39.666666666666671" width="343" height="34.333333333333329"/>
+                                                <rect key="frame" x="16" y="37.666666666666671" width="343" height="34.333333333333329"/>
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="2ie-Qz-tbo" secondAttribute="height" multiplier="10:1" id="Jro-7s-hEf"/>
@@ -410,19 +410,19 @@
                                                 <locale key="locale" localeIdentifier="ja_JP"/>
                                             </datePicker>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="BSq-yI-X1g" userLabel="Game Data Edit Stack View">
-                                                <rect key="frame" x="16" y="90" width="343" height="78"/>
+                                                <rect key="frame" x="16" y="88" width="343" height="80"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MM1-b1-LUu" userLabel="Team Edit Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="35"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VS " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ygs-v4-BCY">
-                                                                <rect key="frame" x="0.0" y="0.0" width="33" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="33" height="35"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="22"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="相手チーム" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ke2-7z-oI5">
-                                                                <rect key="frame" x="49" y="0.0" width="294" height="34"/>
+                                                                <rect key="frame" x="49" y="0.0" width="294" height="35"/>
                                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
@@ -430,22 +430,22 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-24" translatesAutoresizingMaskIntoConstraints="NO" id="ycG-9u-4q1" userLabel="Score Edit Stack View">
-                                                        <rect key="frame" x="0.0" y="44" width="343" height="34"/>
+                                                        <rect key="frame" x="0.0" y="45" width="343" height="35"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LqK-vz-phX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="130.33333333333334" height="35"/>
                                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJp-JM-Oor">
-                                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="34"/>
+                                                                <rect key="frame" x="106.33333333333333" y="0.0" width="130.33333333333337" height="35"/>
                                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="スコア" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9Vv-ke-i6a">
-                                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="34"/>
+                                                                <rect key="frame" x="212.66666666666663" y="0.0" width="130.33333333333337" height="35"/>
                                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                                 <textInputTraits key="textInputTraits"/>


### PR DESCRIPTION
## clone コマンド
git clone -b refactor/game-registerVC https://github.com/hidec-7/MySoccerNoteApp.git

## 概要
### 試合登録画面の軽微なUI変更
- Labelの文字のサイズ、スペースを変更
- ScrollViewの高さを変更
- 入力部分の背景色を薄いグレーにして、視覚的に入力可能な部分であるように変更
### setupメソッドをdidsetでItemに直接セットアップにリファクタリング
例 `setupKeyboardメソッド` -> 
`@IBOutlet private weak var myScoreTextField: UITextField! {
        didSet {
            myScoreTextField.keyboardType = UIKeyboardType.numberPad
        }
    }`

## 実機build/期待通りの挙動をするか
OK

## 11 Pro や SE など大きさが異なる端末のレイアウトが崩れていないか？
OK